### PR TITLE
Rixed runtime casting problem when using sqlline/lingua

### DIFF
--- a/src/main/java/net/hydromatic/optiq/jdbc/Helper.java
+++ b/src/main/java/net/hydromatic/optiq/jdbc/Helper.java
@@ -83,6 +83,14 @@ public class Helper {
       throw new RuntimeException(e);
     }
   }
+
+/** Workaround hack for odd case where instantiating the class dynamically produces
+ * a method not found error (e.g. when Lingual get primary keys
+ */
+  public ResultSet createEmptyResultSet(OptiqConnectionImpl connection) {
+    return createEmptyResultSet((OptiqConnection) connection);
+  }
+
 }
 
 // End Helper.java


### PR DESCRIPTION
Was getting this odd stacktrace even though compile was clean. Having both method signatures available seems to fix the issue. Since the calls in OptiqDatabaseMetaData needs to do doing OptiqConnectionImpl specific operations the double-signature seems less silly than repeated casting.

0: jdbc:lingual:local> select \* from EMPLOYEES.DEPARTMENTS ;
2013-06-11 10:53:05,386 INFO  [main] jdbc.LingualStatement (LingualStatement.java:execute(210)) - execute: select \* from EMPLOYEES.DEPARTMENTS
java.lang.NoSuchMethodError: net.hydromatic.optiq.jdbc.Helper.createEmptyResultSet(Lnet/hydromatic/optiq/jdbc/OptiqConnectionImpl;)Ljava/sql/ResultSet;
    at net.hydromatic.optiq.jdbc.OptiqDatabaseMetaData.getPrimaryKeys(OptiqDatabaseMetaData.java:590)
    at cascading.lingual.jdbc.LingualDatabaseMetaData.getPrimaryKeys(LingualDatabaseMetaData.java:838)
    at sqlline.SqlLine$Rows.isPrimaryKey(SqlLine.java:2389)
    at sqlline.SqlLine$TableOutputFormat.getOutputString(SqlLine.java:2301)
    at sqlline.SqlLine$TableOutputFormat.getOutputString(SqlLine.java:2285)
    at sqlline.SqlLine$TableOutputFormat.print(SqlLine.java:2232)
    at sqlline.SqlLine.print(SqlLine.java:1889)
    at sqlline.SqlLine$Commands.execute(SqlLine.java:3837)
    at sqlline.SqlLine$Commands.sql(SqlLine.java:3738)
    at sqlline.SqlLine.dispatch(SqlLine.java:882)
    at sqlline.SqlLine.begin(SqlLine.java:717)
    at sqlline.SqlLine.mainWithInputRedirection(SqlLine.java:460)
    at sqlline.SqlLine.main(SqlLine.java:443)
    at cascading.lingual.shell.Shell.handle(Shell.java:147)
    at cascading.lingual.shell.Shell.execute(Shell.java:68)
    at cascading.lingual.shell.Shell.main(Shell.java:47)
