### PR TITLE
Add close handler support to OptiqConnection for resource cleanup.

### DIFF
--- a/src/main/java/net/hydromatic/optiq/jdbc/ConnectionCloseHandler.java
+++ b/src/main/java/net/hydromatic/optiq/jdbc/ConnectionCloseHandler.java
@@ -1,0 +1,25 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package net.hydromatic.optiq.jdbc;
+
+import java.sql.SQLException;
+
+public interface ConnectionCloseHandler {
+  public void close() throws SQLException;
+}

--- a/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnection.java
+++ b/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnection.java
@@ -19,7 +19,6 @@ package net.hydromatic.optiq.jdbc;
 
 import net.hydromatic.optiq.MutableSchema;
 import net.hydromatic.optiq.impl.java.JavaTypeFactory;
-
 import net.hydromatic.linq4j.QueryProvider;
 
 import java.sql.Connection;
@@ -75,6 +74,15 @@ public interface OptiqConnection extends Connection, QueryProvider {
 
   // in java.sql.Connection from JDK 1.7, but declare here to allow other JDKs
   String getSchema() throws SQLException;
+  
+  public ConnectionCloseHandler getCloseHandler();
+  
+  /**
+   * Set the connection ${@link ConnectionCloseHandler} for this OptiqConnection.
+   * @param closeHandler Will be informed when this connection is closed.
+   */
+  public void setCloseHandler(ConnectionCloseHandler closeHandler);
+
 }
 
 // End OptiqConnection.java


### PR DESCRIPTION
Adds a ConnectionCloseHandler so that java.sql.Connection.close() also releases other resources.
