### PR TITLE
Changed clearWarnings() to not do UnsupportedOperationException since so...

### DIFF
--- a/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
+++ b/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
@@ -241,7 +241,7 @@ abstract class OptiqConnectionImpl implements OptiqConnection, QueryProvider {
   }
 
   public void clearWarnings() throws SQLException {
-    throw new UnsupportedOperationException();
+    // no-op since connection pooling often calls this.
   }
 
   public Statement createStatement(


### PR DESCRIPTION
Testing with c3p0 and Pentaho (which uses c3p0) shows that this method gets called when connections are put back in a connection pool. Throwing an UnsupportedOpException causes the pool to either fail or mark the connection as bad so just no-op.
