### PR TITLE
Date handling improvements

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/JavaTypeFactoryImpl.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.*;
 
 /**
@@ -128,11 +130,14 @@ public class JavaTypeFactoryImpl
       case CHAR:
         return String.class;
       case DATE:
+        return Date.class;
       case TIME:
+        return Time.class;
       case INTEGER:
       case INTERVAL_YEAR_MONTH:
         return type.isNullable() ? Integer.class : int.class;
       case TIMESTAMP:
+        return Timestamp.class;
       case BIGINT:
       case INTERVAL_DAY_TIME:
         return type.isNullable() ? Long.class : long.class;

--- a/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
@@ -101,8 +101,10 @@ public abstract class AbstractCursor implements Cursor {
         return new DateFromIntAccessor(getter, localCalendar);
       case JAVA_SQL_DATE:
         return new DateAccessor(getter, localCalendar);
+      case JAVA_UTIL_DATE:
+        return new DateAccessor(getter, localCalendar);
       default:
-        throw new AssertionError("bad " + type.representation);
+        throw new AssertionError("invalid type representation " + type.representation);
       }
     case Types.TIME:
       switch (type.representation) {
@@ -112,7 +114,7 @@ public abstract class AbstractCursor implements Cursor {
       case JAVA_SQL_TIME:
         return new TimeAccessor(getter, localCalendar);
       default:
-        throw new AssertionError("bad " + type.representation);
+        throw new AssertionError("invalid type representation " + type.representation);
       }
     case Types.TIMESTAMP:
       switch (type.representation) {
@@ -124,7 +126,7 @@ public abstract class AbstractCursor implements Cursor {
       case JAVA_UTIL_DATE:
         return new TimestampFromUtilDateAccessor(getter, localCalendar);
       default:
-        throw new AssertionError("bad " + type.representation);
+        throw new AssertionError("invalid type representation " + type.representation);
       }
     case Types.JAVA_OBJECT:
     case Types.ARRAY:


### PR DESCRIPTION
RelDataType values representing dates/times resolved to more specific java class.
Cursor uses same kind of Accessor for java.util.Date that it used for java.sql.Date.
