### PR TITLE
Modify type checkers to accept 'ANY' type

### DIFF
--- a/core/src/main/java/org/eigenbase/sql/type/FamilyOperandTypeChecker.java
+++ b/core/src/main/java/org/eigenbase/sql/type/FamilyOperandTypeChecker.java
@@ -76,6 +76,11 @@ public class FamilyOperandTypeChecker
                 callBinding.getScope(),
                 node);
         SqlTypeName typeName = type.getSqlTypeName();
+
+        /* Pass type checking for operators if its of type 'ANY' */
+        if (typeName.getFamily() == SqlTypeFamily.ANY)
+            return true;
+
         if (!family.getTypeNames().contains(typeName)) {
             if (throwOnFailure) {
                 throw callBinding.newValidationSignatureError();

--- a/core/src/main/java/org/eigenbase/sql/type/SqlTypeAssignmentRules.java
+++ b/core/src/main/java/org/eigenbase/sql/type/SqlTypeAssignmentRules.java
@@ -305,6 +305,11 @@ public class SqlTypeAssignmentRules
         rule.add(SqlTypeName.CHAR);
         rule.add(SqlTypeName.VARCHAR);
         coerceRules.put(SqlTypeName.TIMESTAMP, rule);
+
+        /* Any is assignable from Any */
+        rule = new HashSet<SqlTypeName>();
+        rule.add(SqlTypeName.ANY);
+        rules.put(SqlTypeName.ANY, rule);
     }
 
     //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/eigenbase/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/eigenbase/sql/type/SqlTypeUtil.java
@@ -1322,6 +1322,12 @@ public abstract class SqlTypeUtil
         if (family1 == family2) {
             return true;
         }
+
+        /* If one of the operators is of type 'ANY', return true */
+        if (family1 == SqlTypeFamily.ANY ||
+            family2 == SqlTypeFamily.ANY)
+            return true;
+
         return false;
     }
 


### PR DESCRIPTION
I discussed some of the approaches we could use to get rid of the 'cast' from the Drill SQL with Jacques and arrived at the conclusion that modifying checkOperandType() to allow 'ANY' seems like the better approach.

Modifying SqlTypeStrategies seems like a lot more intrusive and the amount of permutations we would need to use for every operator makes it messy.

Seems to me that since Optiq supports the notion of 'ANY' type inherently, its type checkers should allow 'ANY' type to work well with other types (including 'ANY' itself). So all the operand type checkers should/can be aware of this type.

I've modified a couple of functions to just showcase how I was planning to proceed, haven't added tests or anything. This is an exercise to make sure the approach we are taking is fine. Let us know your thoughts.
