### PR TITLE
Proposed optiq version 0.4.12.2

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/ConnectionProperty.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/ConnectionProperty.java
@@ -38,7 +38,10 @@ public enum ConnectionProperty {
   /** Specifies whether Spark should be used as the engine for processing that
    * cannot be pushed to the source system. If false (the default), Optiq
    * generates code that implements the Enumerable interface. */
-  SPARK("spark", Type.BOOLEAN, "false");
+  SPARK("spark", Type.BOOLEAN, "false"),
+
+  /** Timezone, for example 'gmt-3'. Default is the JVM's time zone. */
+  TIMEZONE("timezone", Type.STRING, null);
 
   private final String camelName;
   private final Type type;

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/Helper.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/Helper.java
@@ -17,14 +17,15 @@
 */
 package net.hydromatic.optiq.jdbc;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+
 import net.hydromatic.linq4j.function.Function0;
 import net.hydromatic.optiq.runtime.ColumnMetaData;
 import net.hydromatic.optiq.runtime.Cursor;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Utility methods, mainly concerning error-handling.
@@ -68,7 +69,7 @@ public class Helper {
             public Cursor apply() {
               return new Cursor() {
                 public List<Accessor> createAccessors(
-                    List<ColumnMetaData> types) {
+                    List<ColumnMetaData> types, Calendar localCalendar) {
                   assert types.isEmpty();
                   return Collections.emptyList();
                 }

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
@@ -56,53 +56,7 @@ abstract class OptiqConnectionImpl implements OptiqConnection, QueryProvider {
 
   final ParameterExpression rootExpression =
       Expressions.parameter(DataContext.class, "root");
-  final MutableSchema rootSchema =
-      new MapSchema(null, this, typeFactory, "", rootExpression) {
-        private Object sparkContext;
-
-        // Store the time at which the query started executing. The SQL
-        // standard says that functions such as CURRENTTIMESTAMP return the
-        // same value throughout the query.
-        final long time = System.currentTimeMillis();
-        final long localOffset =
-            Calendar.getInstance().getTimeZone().getOffset(time);
-        final long currentOffset = localOffset;
-        private final ImmutableMap<Object, Object> map =
-            ImmutableMap.builder()
-                .put("utcTimestamp", time)
-                .put("currentTimestamp", time + currentOffset)
-                .put("localTimestamp", time + localOffset)
-                .build();
-
-        @Override
-        public synchronized Object get(String name) {
-          if (name.equals("sparkContext")) {
-            if (sparkContext == null) {
-              try {
-                final Class<?> clazz =
-                    Class.forName("org.apache.spark.api.java.JavaSparkContext");
-                final Constructor<?> constructor =
-                    clazz.getConstructor(String.class, String.class);
-                sparkContext = constructor.newInstance("local[1]", "optiq");
-              } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-              } catch (InvocationTargetException e) {
-                throw new RuntimeException(e);
-              } catch (NoSuchMethodException e) {
-                throw new RuntimeException(e);
-              } catch (InstantiationException e) {
-                throw new RuntimeException(e);
-              } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-              }
-            }
-            return sparkContext;
-          } else {
-            return map.get(name);
-          }
-        }
-      };
-
+  final MutableSchema rootSchema;
   final UnregisteredDriver driver;
   final net.hydromatic.optiq.jdbc.Factory factory;
   final Function0<OptiqPrepare> prepareFactory;
@@ -138,6 +92,7 @@ abstract class OptiqConnectionImpl implements OptiqConnection, QueryProvider {
     this.info = info;
     this.metaData = factory.newDatabaseMetaData(this);
     this.holdability = metaData.getResultSetHoldability();
+    this.rootSchema = new RootSchema(this);
     this.informationSchema = metaData.meta.createInformationSchema();
   }
 
@@ -513,6 +468,45 @@ abstract class OptiqConnectionImpl implements OptiqConnection, QueryProvider {
 
     public void addStatement(OptiqServerStatement statement) {
       statementList.add(statement);
+    }
+  }
+
+  private static class RootSchema extends MapSchema {
+    private final ImmutableMap<Object, Object> map;
+
+    RootSchema(OptiqConnectionImpl connection) {
+      super(
+          null,
+          connection,
+          connection.typeFactory,
+          "",
+          connection.rootExpression);
+
+      // Store the time at which the query started executing. The SQL
+      // standard says that functions such as CURRENTTIMESTAMP return the
+      // same value throughout the query.
+      final long time = System.currentTimeMillis();
+      final String timeZoneName =
+          ConnectionProperty.TIMEZONE.getString(connection.getProperties());
+      final TimeZone timeZone =
+          timeZoneName == null
+              ? TimeZone.getDefault()
+              : TimeZone.getTimeZone(timeZoneName);
+      final long localOffset = timeZone.getOffset(time);
+      final long currentOffset = localOffset;
+
+      map = ImmutableMap.builder()
+          .put("utcTimestamp", time)
+          .put("currentTimestamp", time + currentOffset)
+          .put("localTimestamp", time + localOffset)
+          .put("timeZone", timeZone)
+          .build();
+    }
+
+    @Override
+    public synchronized Object get(String name) {
+      System.out.println(map);
+      return map.get(name);
     }
   }
 }

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqResultSet.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqResultSet.java
@@ -38,6 +38,7 @@ public class OptiqResultSet implements ResultSet {
   private final List<ColumnMetaData> columnMetaDataList;
   private final Function0<Cursor> cursorFactory;
   private final ResultSetMetaData resultSetMetaData;
+  private final Calendar localCalendar;
 
   private Cursor cursor;
   private List<Cursor.Accessor> accessorList;
@@ -73,6 +74,9 @@ public class OptiqResultSet implements ResultSet {
     for (ColumnMetaData column : columnMetaDataList) {
       columnNameMap.put(column.label, columnNameMap.size());
     }
+    final TimeZone timeZone =
+        (TimeZone) statement.connection.rootSchema.get("timeZone");
+    this.localCalendar = Calendar.getInstance(timeZone);
   }
 
   private Cursor.Accessor getAccessor(int columnIndex) {
@@ -149,7 +153,8 @@ public class OptiqResultSet implements ResultSet {
         statement, resultSink);
 
     this.cursor = cursorFactory.apply();
-    this.accessorList = cursor.createAccessors(columnMetaDataList);
+    this.accessorList =
+        cursor.createAccessors(columnMetaDataList, localCalendar);
     accessorMap.clear();
     for (Map.Entry<String, Integer> entry : columnNameMap.entrySet()) {
       accessorMap.put(entry.getKey(), accessorList.get(entry.getValue()));
@@ -214,15 +219,15 @@ public class OptiqResultSet implements ResultSet {
   }
 
   public Date getDate(int columnIndex) throws SQLException {
-    return getAccessor(columnIndex - 1).getDate();
+    return getAccessor(columnIndex - 1).getDate(localCalendar);
   }
 
   public Time getTime(int columnIndex) throws SQLException {
-    return getAccessor(columnIndex - 1).getTime();
+    return getAccessor(columnIndex - 1).getTime(localCalendar);
   }
 
   public Timestamp getTimestamp(int columnIndex) throws SQLException {
-    return getAccessor(columnIndex - 1).getTimestamp();
+    return getAccessor(columnIndex - 1).getTimestamp(localCalendar);
   }
 
   public InputStream getAsciiStream(int columnIndex) throws SQLException {
@@ -279,15 +284,15 @@ public class OptiqResultSet implements ResultSet {
   }
 
   public Date getDate(String columnLabel) throws SQLException {
-    return getAccessor(columnLabel).getDate();
+    return getAccessor(columnLabel).getDate(localCalendar);
   }
 
   public Time getTime(String columnLabel) throws SQLException {
-    return getAccessor(columnLabel).getTime();
+    return getAccessor(columnLabel).getTime(localCalendar);
   }
 
   public Timestamp getTimestamp(String columnLabel) throws SQLException {
-    return getAccessor(columnLabel).getTimestamp();
+    return getAccessor(columnLabel).getTimestamp(localCalendar);
   }
 
   public InputStream getAsciiStream(String columnLabel) throws SQLException {

--- a/core/src/main/java/net/hydromatic/optiq/runtime/ArrayEnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/ArrayEnumeratorCursor.java
@@ -48,7 +48,7 @@ public class ArrayEnumeratorCursor extends AbstractCursor {
     enumerator.close();
   }
 
-  class ArrayEnumeratorGetter implements Getter {
+  class ArrayEnumeratorGetter extends AbstractGetter {
     protected final int field;
 
     public ArrayEnumeratorGetter(int field) {
@@ -59,10 +59,6 @@ public class ArrayEnumeratorCursor extends AbstractCursor {
       Object o = enumerator.current()[field];
       wasNull[0] = (o == null);
       return o;
-    }
-
-    public boolean wasNull() {
-      return wasNull[0];
     }
   }
 }

--- a/core/src/main/java/net/hydromatic/optiq/runtime/Cursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/Cursor.java
@@ -33,10 +33,13 @@ public interface Cursor extends Closeable {
   /**
    * Creates a list of accessors, one per column.
    *
+   *
    * @param types List of column types, per {@link java.sql.Types}.
+   * @param localCalendar Calendar in local timezone
    * @return List of column accessors
    */
-  List<Accessor> createAccessors(List<ColumnMetaData> types);
+  List<Accessor> createAccessors(List<ColumnMetaData> types,
+      Calendar localCalendar);
 
   /**
    * Moves to the next row.
@@ -54,6 +57,8 @@ public interface Cursor extends Closeable {
    * Accessor of a column value.
    */
   interface Accessor {
+    boolean wasNull();
+
     String getString();
 
     boolean getBoolean();
@@ -76,12 +81,6 @@ public interface Cursor extends Closeable {
 
     byte[] getBytes();
 
-    Date getDate();
-
-    Time getTime();
-
-    Timestamp getTimestamp();
-
     InputStream getAsciiStream();
 
     InputStream getUnicodeStream();
@@ -102,11 +101,11 @@ public interface Cursor extends Closeable {
 
     Array getArray();
 
-    Date getDate(Calendar cal);
+    Date getDate(Calendar calendar);
 
-    Time getTime(Calendar cal);
+    Time getTime(Calendar calendar);
 
-    Timestamp getTimestamp(Calendar cal);
+    Timestamp getTimestamp(Calendar calendar);
 
     URL getURL();
 

--- a/core/src/main/java/net/hydromatic/optiq/runtime/ObjectEnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/ObjectEnumeratorCursor.java
@@ -48,7 +48,7 @@ public class ObjectEnumeratorCursor extends AbstractCursor {
     enumerator.close();
   }
 
-  class ObjectEnumeratorGetter implements Getter {
+  class ObjectEnumeratorGetter extends AbstractGetter {
     public ObjectEnumeratorGetter(int field) {
       assert field == 0;
     }
@@ -57,10 +57,6 @@ public class ObjectEnumeratorCursor extends AbstractCursor {
       Object o = enumerator.current();
       wasNull[0] = (o == null);
       return o;
-    }
-
-    public boolean wasNull() {
-      return wasNull[0];
     }
   }
 }

--- a/core/src/main/java/net/hydromatic/optiq/runtime/RecordEnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/RecordEnumeratorCursor.java
@@ -56,7 +56,7 @@ public class RecordEnumeratorCursor<E> extends AbstractCursor {
     enumerator.close();
   }
 
-  class RecordEnumeratorGetter implements Getter {
+  class RecordEnumeratorGetter extends AbstractGetter {
     protected final Field field;
 
     public RecordEnumeratorGetter(Field field) {
@@ -72,10 +72,6 @@ public class RecordEnumeratorCursor<E> extends AbstractCursor {
       }
       wasNull[0] = (o == null);
       return o;
-    }
-
-    public boolean wasNull() {
-      return wasNull[0];
     }
   }
 }

--- a/core/src/main/java/org/eigenbase/util14/DateTimeUtil.java
+++ b/core/src/main/java/org/eigenbase/util14/DateTimeUtil.java
@@ -80,6 +80,11 @@ public class DateTimeUtil
         zeroCalendar.setTimeInMillis(0);
     }
 
+    /**
+     * Calendar set to local time.
+     */
+    private static final Calendar LOCAL_CALENDAR = Calendar.getInstance();
+
     //~ Methods ----------------------------------------------------------------
 
     /**

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -805,7 +805,7 @@ public class JdbcTest {
         .with(OptiqAssert.Config.FOODMART_CLONE)
         .query(
             "select \"hire_date\" from \"employee\" where \"employee_id\" = 1")
-        .returns("hire_date=1994-12-01T08:00:00Z\n");
+        .returns("hire_date=1994-12-01 00:00:00\n");
   }
 
   @Test public void testValues() {
@@ -1603,6 +1603,162 @@ public class JdbcTest {
     resultSet.close();
     statement.close();
     connection.close();
+  }
+
+  /** Test for timestamps and time zones, based on pgsql TimezoneTest. */
+  @Test public void testGetTimestamp() throws Exception {
+    OptiqAssert.assertThat()
+        .with(
+            new OptiqAssert.ConnectionFactory() {
+                public OptiqConnection createConnection() throws Exception {
+                    Class.forName("net.hydromatic.optiq.jdbc.Driver");
+                    final Properties info = new Properties();
+                    info.setProperty("timezone", "GMT+1:00");
+                    return (OptiqConnection) DriverManager.getConnection(
+                        "jdbc:optiq:", info);
+                }
+            })
+        .doWithConnection(
+            new Function1<OptiqConnection, Void>() {
+              public Void apply(OptiqConnection connection) {
+                try {
+                  checkGetTimestamp(connection);
+                  return null;
+                } catch (SQLException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+  }
+
+  private void checkGetTimestamp(Connection con) throws SQLException {
+    Statement statement = con.createStatement();
+
+    // Not supported yet. We set timezone using connect-string parameters.
+    //statement.executeUpdate("alter session set timezone = 'gmt-3'");
+
+    ResultSet rs = statement.executeQuery(
+        "SELECT * FROM (VALUES(\n"
+        + " TIMESTAMP '1970-01-01 00:00:00',\n"
+        + " /* TIMESTAMP '2005-01-01 15:00:00 +0300', */\n"
+        + " TIMESTAMP '2005-01-01 15:00:00',\n"
+        + " TIME '15:00:00',\n"
+        + " /* TIME '15:00:00 +0300', */\n"
+        + " DATE '2005-01-01'\n"
+        + ")) AS t(ts0, /* tstz, */ ts, t, /* tz, */ d)");
+    assertTrue(rs.next());
+
+    TimeZone UTC   = TimeZone.getTimeZone("UTC");    // +0000 always
+    TimeZone GMT03 = TimeZone.getTimeZone("GMT+03"); // +0300 always
+    TimeZone GMT05 = TimeZone.getTimeZone("GMT-05"); // -0500 always
+    TimeZone GMT13 = TimeZone.getTimeZone("GMT+13"); // +1000 always
+
+    Calendar cUTC   = Calendar.getInstance(UTC);
+    Calendar cGMT03 = Calendar.getInstance(GMT03);
+    Calendar cGMT05 = Calendar.getInstance(GMT05);
+    Calendar cGMT13 = Calendar.getInstance(GMT13);
+
+    Timestamp ts;
+    String s;
+    int c = 1;
+
+    // timestamp: 1970-01-01 00:00:00
+    ts = rs.getTimestamp(c);                     // Convert timestamp to +0100
+    assertEquals(-3600000L,      ts.getTime());  // 1970-01-01 00:00:00 +0100
+    ts = rs.getTimestamp(c, cUTC);               // Convert timestamp to UTC
+    assertEquals(0L,             ts.getTime());  // 1970-01-01 00:00:00 +0000
+    ts = rs.getTimestamp(c, cGMT03);             // Convert timestamp to +0300
+    assertEquals(-10800000L,     ts.getTime());  // 1970-01-01 00:00:00 +0300
+    ts = rs.getTimestamp(c, cGMT05);             // Convert timestamp to -0500
+    assertEquals(18000000L,      ts.getTime());  // 1970-01-01 00:00:00 -0500
+    ts = rs.getTimestamp(c, cGMT13);             // Convert timestamp to +1300
+    assertEquals(-46800000,      ts.getTime());  // 1970-01-01 00:00:00 +1300
+    s = rs.getString(c);
+    assertEquals("1970-01-01 00:00:00", s);
+    ++c;
+
+    if (false) {
+      // timestamptz: 2005-01-01 15:00:00+03
+      ts = rs.getTimestamp(c);                      // Represents an instant in
+                                                    // time, TZ is irrelevant.
+      assertEquals(1104580800000L, ts.getTime());   // 2005-01-01 12:00:00 UTC
+      ts = rs.getTimestamp(c, cUTC);                // TZ irrelevant, as above
+      assertEquals(1104580800000L, ts.getTime());   // 2005-01-01 12:00:00 UTC
+      ts = rs.getTimestamp(c, cGMT03);              // TZ irrelevant, as above
+      assertEquals(1104580800000L, ts.getTime());   // 2005-01-01 12:00:00 UTC
+      ts = rs.getTimestamp(c, cGMT05);              // TZ irrelevant, as above
+      assertEquals(1104580800000L, ts.getTime());   // 2005-01-01 12:00:00 UTC
+      ts = rs.getTimestamp(c, cGMT13);              // TZ irrelevant, as above
+      assertEquals(1104580800000L, ts.getTime());   // 2005-01-01 12:00:00 UTC
+      ++c;
+    }
+
+    // timestamp: 2005-01-01 15:00:00
+    ts = rs.getTimestamp(c);                     // Convert timestamp to +0100
+    assertEquals(1104588000000L, ts.getTime());  // 2005-01-01 15:00:00 +0100
+    ts = rs.getTimestamp(c, cUTC);               // Convert timestamp to UTC
+    assertEquals(1104591600000L, ts.getTime());  // 2005-01-01 15:00:00 +0000
+    ts = rs.getTimestamp(c, cGMT03);             // Convert timestamp to +0300
+    assertEquals(1104580800000L, ts.getTime());  // 2005-01-01 15:00:00 +0300
+    ts = rs.getTimestamp(c, cGMT05);             // Convert timestamp to -0500
+    assertEquals(1104609600000L, ts.getTime());  // 2005-01-01 15:00:00 -0500
+    ts = rs.getTimestamp(c, cGMT13);             // Convert timestamp to +1300
+    assertEquals(1104544800000L, ts.getTime());  // 2005-01-01 15:00:00 +1300
+    s = rs.getString(c);
+    assertEquals("2005-01-01 15:00:00", s);
+    ++c;
+
+    // time: 15:00:00
+    ts = rs.getTimestamp(c);
+    assertEquals(50400000L, ts.getTime());        // 1970-01-01 15:00:00 +0100
+    ts = rs.getTimestamp(c, cUTC);
+    assertEquals(54000000L, ts.getTime());        // 1970-01-01 15:00:00 +0000
+    ts = rs.getTimestamp(c, cGMT03);
+    assertEquals(43200000L, ts.getTime());        // 1970-01-01 15:00:00 +0300
+    ts = rs.getTimestamp(c, cGMT05);
+    assertEquals(72000000L, ts.getTime());        // 1970-01-01 15:00:00 -0500
+    ts = rs.getTimestamp(c, cGMT13);
+    assertEquals(7200000L, ts.getTime());         // 1970-01-01 15:00:00 +1300
+    s = rs.getString(c);
+    assertEquals("15:00:00", s);
+    ++c;
+
+    if (false) {
+      // timetz: 15:00:00+03
+      ts = rs.getTimestamp(c);
+      assertEquals(43200000L, ts.getTime());    // 1970-01-01 15:00:00 +0300 ->
+                                                // 1970-01-01 13:00:00 +0100
+      ts = rs.getTimestamp(c, cUTC);
+      assertEquals(43200000L, ts.getTime());    // 1970-01-01 15:00:00 +0300 ->
+                                                // 1970-01-01 12:00:00 +0000
+      ts = rs.getTimestamp(c, cGMT03);
+      assertEquals(43200000L, ts.getTime());    // 1970-01-01 15:00:00 +0300 ->
+                                                // 1970-01-01 15:00:00 +0300
+      ts = rs.getTimestamp(c, cGMT05);
+      assertEquals(43200000L, ts.getTime());    // 1970-01-01 15:00:00 +0300 ->
+                                                // 1970-01-01 07:00:00 -0500
+      ts = rs.getTimestamp(c, cGMT13);
+      assertEquals(43200000L, ts.getTime());    // 1970-01-01 15:00:00 +0300 ->
+                                                // 1970-01-02 01:00:00 +1300
+      ++c;
+    }
+
+    // date: 2005-01-01
+    ts = rs.getTimestamp(c);
+    assertEquals(1104534000000L, ts.getTime()); // 2005-01-01 00:00:00 +0100
+    ts = rs.getTimestamp(c, cUTC);
+    assertEquals(1104537600000L, ts.getTime()); // 2005-01-01 00:00:00 +0000
+    ts = rs.getTimestamp(c, cGMT03);
+    assertEquals(1104526800000L, ts.getTime()); // 2005-01-01 00:00:00 +0300
+    ts = rs.getTimestamp(c, cGMT05);
+    assertEquals(1104555600000L, ts.getTime()); // 2005-01-01 00:00:00 -0500
+    ts = rs.getTimestamp(c, cGMT13);
+    assertEquals(1104490800000L, ts.getTime()); // 2005-01-01 00:00:00 +1300
+    s = rs.getString(c);
+    assertEquals("2005-01-01", s);              // 2005-01-01 00:00:00 +0100
+    ++c;
+
+    assertTrue(!rs.next());
   }
 
   public static class HrSchema {

--- a/core/src/test/java/net/hydromatic/optiq/test/OptiqAssert.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/OptiqAssert.java
@@ -352,13 +352,14 @@ public class OptiqAssert {
 
   static String toString(ResultSet resultSet) throws SQLException {
     final StringBuilder buf = new StringBuilder();
+    final ResultSetMetaData metaData = resultSet.getMetaData();
     while (resultSet.next()) {
-      int n = resultSet.getMetaData().getColumnCount();
+      int n = metaData.getColumnCount();
       if (n > 0) {
         for (int i = 1;; i++) {
-          buf.append(resultSet.getMetaData().getColumnLabel(i))
+          buf.append(metaData.getColumnLabel(i))
               .append("=")
-              .append(str(resultSet, i));
+              .append(resultSet.getString(i));
           if (i == n) {
             break;
           }
@@ -379,7 +380,7 @@ public class OptiqAssert {
         for (int i = 1;; i++) {
           buf.append(resultSet.getMetaData().getColumnLabel(i))
               .append("=")
-              .append(str(resultSet, i));
+              .append(resultSet.getString(i));
           if (i == n) {
             break;
           }

--- a/core/src/test/java/org/eigenbase/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/eigenbase/sql/test/SqlOperatorBaseTest.java
@@ -3763,6 +3763,12 @@ public abstract class SqlOperatorBaseTest {
                 currentTimeString(LOCAL_TZ).substring(11)
                 + "[0-9][0-9]:[0-9][0-9]"),
             "VARCHAR(30) NOT NULL");
+        tester.checkScalar(
+            "LOCALTIME",
+            Pattern.compile(
+                currentTimeString(LOCAL_TZ).substring(11)
+                + "[0-9][0-9]:[0-9][0-9]"),
+            "TIME(0) NOT NULL");
     }
 
     @Test public void testLocalTimestampFunc() {
@@ -3790,6 +3796,12 @@ public abstract class SqlOperatorBaseTest {
                 currentTimeString(LOCAL_TZ)
                 + "[0-9][0-9]:[0-9][0-9]"),
             "VARCHAR(30) NOT NULL");
+        tester.checkScalar(
+            "LOCALTIMESTAMP",
+            Pattern.compile(
+                currentTimeString(LOCAL_TZ)
+                + "[0-9][0-9]:[0-9][0-9]"),
+            "TIMESTAMP(0) NOT NULL");
     }
 
     @Test public void testCurrentTimeFunc() {
@@ -3811,6 +3823,12 @@ public abstract class SqlOperatorBaseTest {
                 currentTimeString(CURRENT_TZ).substring(11)
                 + "[0-9][0-9]:[0-9][0-9]"),
             "VARCHAR(30) NOT NULL");
+        tester.checkScalar(
+            "CURRENT_TIME",
+            Pattern.compile(
+                currentTimeString(CURRENT_TZ).substring(11)
+                + "[0-9][0-9]:[0-9][0-9]"),
+            "TIME(0) NOT NULL");
     }
 
     @Test public void testCurrentTimestampFunc() {
@@ -3836,6 +3854,12 @@ public abstract class SqlOperatorBaseTest {
                 currentTimeString(CURRENT_TZ)
                 + "[0-9][0-9]:[0-9][0-9]"),
                 "VARCHAR(30) NOT NULL");
+        tester.checkScalar(
+            "CURRENT_TIMESTAMP",
+            Pattern.compile(
+                currentTimeString(CURRENT_TZ)
+                + "[0-9][0-9]:[0-9][0-9]"),
+                "TIMESTAMP(0) NOT NULL");
     }
 
     /**
@@ -3878,6 +3902,10 @@ public abstract class SqlOperatorBaseTest {
             "CAST(CURRENT_DATE AS VARCHAR(30))",
             currentTimeString(LOCAL_TZ).substring(0, 10),
             "VARCHAR(30) NOT NULL");
+        tester.checkScalar(
+            "CURRENT_DATE",
+            currentTimeString(LOCAL_TZ).substring(0, 10),
+            "DATE NOT NULL");
     }
 
     @Test public void testSubstringFunction() {


### PR DESCRIPTION
Cherry-picked and merged the commit that included UTC support, CURRENT_DATE, etc.

Implement CURRENT_DATE, LOCALTIMESTAMP, etc.

Add connect string property "timezone".
Use local timezone when returning Time, Date, Timestamp values from JDBC.

Conflicts:
    core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
    core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
    core/src/main/java/net/hydromatic/optiq/runtime/SqlFunctions.java
    core/src/test/java/net/hydromatic/optiq/test/OptiqAssert.java
