### PR TITLE
Allow developers to override the methods Optiq uses to implement within ...

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqPrepare.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqPrepare.java
@@ -201,6 +201,10 @@ public interface OptiqPrepare {
       return columnList;
     }
 
+    public Bindable<T> getBindable(){
+      return bindable;
+    }
+    
     public List<AvaticaParameter> getParameterList() {
       return parameterList;
     }

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
@@ -30,6 +30,7 @@ import net.hydromatic.optiq.Table;
 import net.hydromatic.optiq.impl.java.JavaTypeFactory;
 import net.hydromatic.optiq.jdbc.OptiqPrepare;
 import net.hydromatic.optiq.materialize.MaterializationService;
+import net.hydromatic.optiq.prepare.Prepare.CatalogReader;
 import net.hydromatic.optiq.rules.java.*;
 import net.hydromatic.optiq.runtime.*;
 import net.hydromatic.optiq.server.OptiqServerStatement;
@@ -272,8 +273,7 @@ public class OptiqPrepareImpl implements OptiqPrepare {
     } else {
       prefer = EnumerableRel.Prefer.CUSTOM;
     }
-    final OptiqPreparingStmt preparingStmt =
-        new OptiqPreparingStmt(
+    final OptiqPreparingStmt preparingStmt = getPrepare(
             context,
             catalogReader,
             typeFactory,
@@ -420,8 +420,7 @@ public class OptiqPrepareImpl implements OptiqPrepare {
               Schemas.root(schema),
               butLast(materialization.materializedTable.path()),
               context.getTypeFactory());
-      final OptiqPreparingStmt preparingStmt =
-          new OptiqPreparingStmt(context, catalogReader,
+      final OptiqPreparingStmt preparingStmt = getPrepare(context, catalogReader,
               catalogReader.getTypeFactory(),
               schema, EnumerableRel.Prefer.ANY, planner,
               EnumerableConvention.INSTANCE);
@@ -461,7 +460,17 @@ public class OptiqPrepareImpl implements OptiqPrepare {
     return action.apply(cluster, catalogReader, context.getRootSchema());
   }
 
-  private static class OptiqPreparingStmt extends Prepare {
+  protected OptiqPreparingStmt getPrepare(Context context,
+      CatalogReader catalogReader,
+      RelDataTypeFactory typeFactory,
+      Schema schema,
+      EnumerableRel.Prefer prefer,
+      RelOptPlanner planner,
+      Convention resultConvention){
+    return new OptiqPreparingStmt(context, catalogReader, typeFactory, schema, prefer, planner, resultConvention);
+  }
+  
+  protected static class OptiqPreparingStmt extends Prepare {
     private final RelOptPlanner planner;
     private final RexBuilder rexBuilder;
     private final Context context;

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>[4.8,)</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -206,6 +206,35 @@
         <version>2.4.1</version>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>javacc-maven-plugin</artifactId>
+                    <versionRange>[2.4,)</versionRange>
+                    <goals>
+                      <goal>javacc</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <reporting>


### PR DESCRIPTION
...prepare.  This allows hacky solutions to parsing SQL and getting the RelNode back without having to jump through the implement hoops.  I’d prefer a cleaner way to skip over the implementation phase and just get the plan back for additional optimization.
