### PR TITLE
Disable spark module by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ $ cd optiq
 $ mvn install
 ```
 
+Use `-DskipTests` if you do not want to execute the tests.
+The `spark` module is excluded from the build by default. To enable it, activate the `spark` maven build profile:
+```bash
+mvn install -Pspark
+```
+
 Example
 =======
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,6 @@
     <module>core</module>
     <module>mongodb</module>
     <module>splunk</module>
-    <!-- disabled because you need to build spark yourself -->
-    <module>spark</module>
-    <!-- -->
   </modules>
 
   <!-- Dependencies. -->


### PR DESCRIPTION
Hi,

The mvn build was not working out of the box (which should be the case, in my opinion) so I fixed the maven profiles and documented them.

I'm really new to the project, might be that I did something wrong with the spark module (then, consider this as an issue)

I got this error message:

```
[ERROR] Failed to execute goal on project optiq-spark: Could not resolve dependencies for project net.hydromatic:optiq-spark:jar:0.4.17-SNAPSHOT: Failure to find org.apache.spark:spark-core:jar:0.8.0-20130911.235955-2 in http://repo.pentaho.org/artifactory/repo was cached in the local repository, resolution will not be reattempted until the update interval of pentaho has elapsed or updates are forced -> [Help 1]
```
