### PR TITLE
remove references to VolcanoCost from RelSubset

### DIFF
--- a/core/src/main/java/org/eigenbase/relopt/volcano/RelSubset.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/RelSubset.java
@@ -85,7 +85,7 @@ public class RelSubset extends AbstractRelNode {
   //~ Methods ----------------------------------------------------------------
 
   private RelOptCost computeBestCost(RelOptPlanner planner) {
-    RelOptCost bestCost = VolcanoCost.INFINITY;
+    RelOptCost bestCost = planner.makeInfiniteCost();
     for (RelNode rel : getRels()) {
       final RelOptCost cost = planner.getCost(rel);
       if (cost.isLt(bestCost)) {
@@ -117,7 +117,7 @@ public class RelSubset extends AbstractRelNode {
 
   public double getRows() {
     if (best == null) {
-      return VolcanoCost.INFINITY.getRows();
+      return Double.POSITIVE_INFINITY;
     } else {
       return RelMetadataQuery.getRowCount(best);
     }


### PR DESCRIPTION
This enables us to use a different RelOptCost(we are experimenting with
HiveCost).
Currently we are also extending VolcanoPlanner to override cost
functions. As discussed long term may be better to have a separate
entity for cost functions.
