### PR TITLE
Fix SqlValidator to rely on RelDataType to do field name matching.

### DIFF
--- a/core/src/main/java/org/eigenbase/reltype/RelDataTypeImpl.java
+++ b/core/src/main/java/org/eigenbase/reltype/RelDataTypeImpl.java
@@ -25,6 +25,7 @@ import org.eigenbase.sql.*;
 import org.eigenbase.sql.parser.*;
 import org.eigenbase.sql.type.*;
 import org.eigenbase.util.Pair;
+import org.eigenbase.util.Util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -76,7 +77,7 @@ public abstract class RelDataTypeImpl
   // implement RelDataType
   public RelDataTypeField getField(String fieldName, boolean caseSensitive) {
     for (RelDataTypeField field : fieldList) {
-      if (field.getName().equals(fieldName)) {
+      if (Util.match(caseSensitive, field.getName(), fieldName)) {
         return field;
       }
     }

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorUtil.java
@@ -85,11 +85,10 @@ public class SqlValidatorUtil {
       boolean caseSensitive,
       final RelDataType rowType,
       String columnName) {
-    for (RelDataTypeField field : rowType.getFieldList()) {
-      if (Util.match(caseSensitive, columnName, field.getName())) {
-        return field;
-      }
-    }
+    
+    RelDataTypeField field = rowType.getField(columnName, caseSensitive);
+    if(field != null) return field;
+    
     // If record type is flagged as having "any field you ask for",
     // return a type. (TODO: Better way to mark accommodating types.)
     RelDataTypeField extra = RelDataTypeImpl.extra(rowType);


### PR DESCRIPTION
In order to get tests to pass, also need to fix RelDataTypeImpl to correctly use the case sensitive flag rather than ignoring it.
