### PR TITLE
Add clear() to RelOptPlanner. PlannerImpl.transform() call clear().

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
@@ -190,6 +190,7 @@ public class PlannerImpl implements Planner {
     ensure(State.STATE_5_CONVERTED);
     RuleSet ruleSet = ruleSets.get(ruleSetIndex);
     planner.clearRules();
+    planner.clear();
     for (RelOptRule rule : ruleSet) {
       planner.addRule(rule);
     }

--- a/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
@@ -73,6 +73,8 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   //~ Methods ----------------------------------------------------------------
 
+  public void clear() {}
+
   public RelOptCostFactory getCostFactory() {
     return costFactory;
   }

--- a/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
@@ -74,6 +74,11 @@ public interface RelOptPlanner {
   void clearRules();
 
   /**
+   * Remove all internal status of planner.
+   */
+  void clear();
+
+  /**
    * Registers a rule. If the rule has already been registered, does nothing.
    * This method should determine if the given rule is a {@link
    * org.eigenbase.rel.convert.ConverterRule} and pass the ConverterRule to

--- a/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
@@ -1680,6 +1680,14 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     pop(ruleCallStack, ruleCall);
   }
 
+  public void clear() {
+    this.allOperands.clear();
+    this.allSets.clear();
+    this.mapDigestToRel.clear();
+    this.mapRel2Subset.clear();
+    this.relImportances.clear();
+  }
+
   //~ Inner Classes ----------------------------------------------------------
 
   /**


### PR DESCRIPTION
Hi Julian,

This is the code I modified in my local branch, which will clear the internal status of RelOptPlanner in the PlannerImpl.transform(). 

The reason for adding clear() is because we want to call transform() multiple times, and RelOptPlanner would hit problem during the second call of transform(), because it still has the status from the first call of transform(). 

Please take a look and see if this is the right fix to address the issue.  Thanks! 
