### PR TITLE
Allow quoting, quotedCasing, unquotedCasing, and caseSensitive properties

### DIFF
--- a/avatica/src/main/java/net/hydromatic/avatica/AvaticaDatabaseMetaData.java
+++ b/avatica/src/main/java/net/hydromatic/avatica/AvaticaDatabaseMetaData.java
@@ -145,11 +145,11 @@ public class AvaticaDatabaseMetaData implements DatabaseMetaData {
   }
 
   public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
-    return caseSensitive() && quotedCasing() == Casing.UNCHANGED;
+    return !caseSensitive() && quotedCasing() == Casing.UNCHANGED;
   }
 
   public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
-    return !caseSensitive() && quotedCasing() == Casing.UNCHANGED;
+    return caseSensitive() && quotedCasing() == Casing.UNCHANGED;
   }
 
   public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {

--- a/avatica/src/main/java/net/hydromatic/avatica/ConnectionProperty.java
+++ b/avatica/src/main/java/net/hydromatic/avatica/ConnectionProperty.java
@@ -35,20 +35,20 @@ public enum ConnectionProperty {
   /** Lexical policy. */
   LEX("lex", Type.ENUM, "ORACLE"),
 
-  /** How identifiers are quoted. */
-  /** default value is based on lex */
+  /** How identifiers are quoted.
+   *  Default value is based on lex. */
   QUOTING("quoting", Type.ENUM, null),
 
-  /** How identifiers are stored if they are quoted. */
-  /** default value is based on lex */
+  /** How identifiers are stored if they are quoted.
+   *  Default value is based on lex. */
   QUOTED_CASING("quotedCasing", Type.ENUM, null),
 
-  /** How identifiers are stored if they are not quoted. */
-  /** default value is based on lex */
+  /** How identifiers are stored if they are not quoted.
+   *  Default value is based on lex. */
   UNQUOTED_CASING("unquotedCasing", Type.ENUM, null),
 
-  /** Whether identifiers are matched case-sensitively. */
-  /** default value is based on lex */
+  /** Whether identifiers are matched case-sensitively.
+   *  Default value is based on lex. */
   CASE_SENSITIVE("caseSensitive", Type.BOOLEAN, null),
 
   /** Name of initial schema. */

--- a/avatica/src/main/java/net/hydromatic/avatica/ConnectionProperty.java
+++ b/avatica/src/main/java/net/hydromatic/avatica/ConnectionProperty.java
@@ -36,7 +36,20 @@ public enum ConnectionProperty {
   LEX("lex", Type.ENUM, "ORACLE"),
 
   /** How identifiers are quoted. */
-  QUOTING("quoting", Type.ENUM, "DOUBLE_QUOTE"),
+  /** default value is based on lex */
+  QUOTING("quoting", Type.ENUM, null),
+
+  /** How identifiers are stored if they are quoted. */
+  /** default value is based on lex */
+  QUOTED_CASING("quotedCasing", Type.ENUM, null),
+
+  /** How identifiers are stored if they are not quoted. */
+  /** default value is based on lex */
+  UNQUOTED_CASING("unquotedCasing", Type.ENUM, null),
+
+  /** Whether identifiers are matched case-sensitively. */
+  /** default value is based on lex */
+  CASE_SENSITIVE("caseSensitive", Type.BOOLEAN, null),
 
   /** Name of initial schema. */
   SCHEMA("schema", Type.STRING, null),
@@ -82,6 +95,12 @@ public enum ConnectionProperty {
   /** Returns the string value of this property, or null if not specified and
    * no default. */
   public String getString(Properties properties) {
+    return getString(properties, defaultValue);
+  }
+
+  /** Returns the string value of this property, or null if not specified and
+   * no default. */
+  public String getString(Properties properties, String defaultValue) {
     assert type == Type.STRING;
     return get_(properties, IDENTITY_CONVERTER, defaultValue);
   }
@@ -89,16 +108,33 @@ public enum ConnectionProperty {
   /** Returns the boolean value of this property. Throws if not set and no
    * default. */
   public boolean getBoolean(Properties properties) {
+    return getBoolean(properties, Boolean.valueOf(defaultValue));
+  }
+
+  /** Returns the boolean value of this property. Throws if not set and no
+   * default. */
+  public boolean getBoolean(Properties properties, boolean defaultValue) {
     assert type == Type.BOOLEAN;
-    return get_(properties, BOOLEAN_CONVERTER, defaultValue);
+    return get_(properties, BOOLEAN_CONVERTER, Boolean.toString(defaultValue));
   }
 
   /** Returns the enum value of this property. Throws if not set and no
    * default. */
-  public <E extends Enum> E getEnum(Properties properties, Class<E> enumClass) {
+  public <E extends Enum<E>> E getEnum(Properties properties
+      , Class<E> enumClass) {
+    return getEnum(properties
+        , enumClass
+        , Enum.valueOf(enumClass, defaultValue)
+    );
+  }
+
+  /** Returns the enum value of this property. Throws if not set and no
+   * default. */
+  public <E extends Enum<E>> E getEnum(Properties properties
+      , Class<E> enumClass, E defaultValue) {
     assert type == Type.ENUM;
     //noinspection unchecked
-    return get_(properties, enumConverter(enumClass), defaultValue);
+    return get_(properties, enumConverter(enumClass), defaultValue.name());
   }
 
   /** Converts a {@link java.util.Properties} object containing (name, value)
@@ -158,14 +194,12 @@ public enum ConnectionProperty {
           throw new RuntimeException("Required property '"
               + connectionProperty.camelName + "' not specified");
         }
-        for (Enum anEnum : enumClass.getEnumConstants()) {
-          if (anEnum.name().equals(s)) {
-            //noinspection unchecked
-            return (E) anEnum;
-          }
+        try {
+          return (E) Enum.valueOf(enumClass, s);
+        } catch (IllegalArgumentException e) {
+          throw new RuntimeException("Property '" + s + "' not valid for enum "
+              + enumClass.getName());
         }
-        throw new RuntimeException("Property '" + s + "' not valid for enum "
-            + enumClass.getName());
       }
     };
   }

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
@@ -80,12 +80,12 @@ abstract class OptiqConnectionImpl
     }
     this.rootSchema = rootSchema;
 
-    final ConnectionConfig.Lex lex =
-        ConnectionProperty.LEX.getEnum(info, ConnectionConfig.Lex.class);
-    this.properties.put(InternalProperty.CASE_SENSITIVE, lex.caseSensitive);
-    this.properties.put(InternalProperty.UNQUOTED_CASING, lex.unquotedCasing);
-    this.properties.put(InternalProperty.QUOTED_CASING, lex.quotedCasing);
-    this.properties.put(InternalProperty.QUOTING, lex.quoting);
+    ConnectionConfig cfg = connectionConfig(info);
+
+    this.properties.put(InternalProperty.CASE_SENSITIVE, cfg.caseSensitive());
+    this.properties.put(InternalProperty.UNQUOTED_CASING, cfg.unquotedCasing());
+    this.properties.put(InternalProperty.QUOTED_CASING, cfg.quotedCasing());
+    this.properties.put(InternalProperty.QUOTING, cfg.quoting());
   }
 
   @Override protected Meta createMeta() {
@@ -124,19 +124,23 @@ abstract class OptiqConnectionImpl
       }
 
       public Quoting quoting() {
-        return lex().quoting;
+        return ConnectionProperty.QUOTING
+            .getEnum(properties, Quoting.class, lex().quoting);
       }
 
       public Casing unquotedCasing() {
-        return lex().unquotedCasing;
+        return ConnectionProperty.UNQUOTED_CASING
+            .getEnum(properties, Casing.class, lex().unquotedCasing);
       }
 
       public Casing quotedCasing() {
-        return lex().quotedCasing;
+        return ConnectionProperty.QUOTED_CASING
+            .getEnum(properties, Casing.class, lex().quotedCasing);
       }
 
       public boolean caseSensitive() {
-        return lex().caseSensitive;
+        return ConnectionProperty.CASE_SENSITIVE
+            .getBoolean(properties, lex().caseSensitive);
       }
 
       public boolean spark() {

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -2881,6 +2881,46 @@ public class JdbcTest {
             });
   }
 
+  /** Tests metadata for the ORACLE lexical scheme overriden like JAVA. */
+  @Test public void testLexOracleAsJava() throws Exception {
+    OptiqAssert.that()
+        .with(ImmutableMap.<String, String>builder()
+            .put("lex", "ORACLE")
+            .put("quoting", "BACK_TICK")
+            .put("unquotedCasing", "UNCHANGED")
+            .put("quotedCasing", "UNCHANGED")
+            .put("caseSensitive", "TRUE")
+            .build())
+        .doWithConnection(
+            new Function1<OptiqConnection, Void>() {
+              public Void apply(OptiqConnection connection) {
+                try {
+                  DatabaseMetaData metaData = connection.getMetaData();
+                  assertThat(metaData.getIdentifierQuoteString(), equalTo("`"));
+                  assertThat(metaData.supportsMixedCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesMixedCaseIdentifiers(),
+                      equalTo(true));
+                  assertThat(metaData.storesUpperCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesLowerCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.supportsMixedCaseQuotedIdentifiers(),
+                      equalTo(true));
+                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesUpperCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
+                      equalTo(false));
+                  return null;
+                } catch (SQLException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+  }
+
   /** Tests that {@link Hook#PARSE_TREE} works. */
   @Test public void testHook() {
     final int[] callCount = {0};

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -2797,9 +2797,9 @@ public class JdbcTest {
                   assertThat(metaData.storesLowerCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.supportsMixedCaseQuotedIdentifiers(),
-                      equalTo(true));
-                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
                       equalTo(false));
+                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
+                      equalTo(true));
                   assertThat(metaData.storesUpperCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
@@ -2831,9 +2831,9 @@ public class JdbcTest {
                   assertThat(metaData.storesLowerCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.supportsMixedCaseQuotedIdentifiers(),
-                      equalTo(true));
-                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
                       equalTo(false));
+                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
+                      equalTo(true));
                   assertThat(metaData.storesUpperCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
@@ -2866,9 +2866,47 @@ public class JdbcTest {
                   assertThat(metaData.storesLowerCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.supportsMixedCaseQuotedIdentifiers(),
-                      equalTo(false));
-                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
                       equalTo(true));
+                  // Oracle JDBC 12.1.0.1.0 returns true here, however it is
+                  // not clear if the bug is in JDBC specification or Oracle
+                  // driver
+                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesUpperCaseQuotedIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
+                      equalTo(false));
+                  return null;
+                } catch (SQLException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+  }
+
+  /** Tests metadata for the JAVA lexical scheme. */
+  @Test public void testLexJava() throws Exception {
+    OptiqAssert.that()
+        .with(ImmutableMap.of("lex", "JAVA"))
+        .doWithConnection(
+            new Function1<OptiqConnection, Void>() {
+              public Void apply(OptiqConnection connection) {
+                try {
+                  DatabaseMetaData metaData = connection.getMetaData();
+                  assertThat(metaData.getIdentifierQuoteString(),
+                      equalTo("`"));
+                  assertThat(metaData.supportsMixedCaseIdentifiers(),
+                      equalTo(true));
+                  assertThat(metaData.storesMixedCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesUpperCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.storesLowerCaseIdentifiers(),
+                      equalTo(false));
+                  assertThat(metaData.supportsMixedCaseQuotedIdentifiers(),
+                      equalTo(true));
+                  assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
+                      equalTo(false));
                   assertThat(metaData.storesUpperCaseQuotedIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
@@ -2896,11 +2934,12 @@ public class JdbcTest {
               public Void apply(OptiqConnection connection) {
                 try {
                   DatabaseMetaData metaData = connection.getMetaData();
-                  assertThat(metaData.getIdentifierQuoteString(), equalTo("`"));
+                  assertThat(metaData.getIdentifierQuoteString(),
+                      equalTo("`"));
                   assertThat(metaData.supportsMixedCaseIdentifiers(),
-                      equalTo(false));
-                  assertThat(metaData.storesMixedCaseIdentifiers(),
                       equalTo(true));
+                  assertThat(metaData.storesMixedCaseIdentifiers(),
+                      equalTo(false));
                   assertThat(metaData.storesUpperCaseIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.storesLowerCaseIdentifiers(),
@@ -2909,7 +2948,7 @@ public class JdbcTest {
                       equalTo(true));
                   assertThat(metaData.storesMixedCaseQuotedIdentifiers(),
                       equalTo(false));
-                  assertThat(metaData.storesUpperCaseIdentifiers(),
+                  assertThat(metaData.storesUpperCaseQuotedIdentifiers(),
                       equalTo(false));
                   assertThat(metaData.storesLowerCaseQuotedIdentifiers(),
                       equalTo(false));

--- a/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
@@ -6383,6 +6383,18 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "RecordType(TIMESTAMP(0) NOT NULL CURRENT_TIMESTAMP) NOT NULL");
   }
 
+  @Test public void testLexAndQuoting() {
+    final SqlTester tester1 = tester
+        .withLex(ConnectionConfig.Lex.JAVA)
+        .withQuoting(Quoting.DOUBLE_QUOTE);
+    // in Java mode, creating identifiers with spaces is not encouraged, but you
+    // can use double-quote if you really have to
+    tester1.checkResultType(
+        "select \"x[y] z \" from (\n"
+        + "  select e.EMPNO as \"x[y] z \" from EMP as e)",
+        "RecordType(INTEGER NOT NULL x[y] z ) NOT NULL");
+  }
+
   /** Tests using case-insensitive matching of identifiers. */
   @Test public void testCaseInsensitive() {
     final SqlTester tester1 = tester


### PR DESCRIPTION
Same as #168, hope you'll squash before merge.

Maybe MySQL lexer should be updated: as per documentation, MySQL case sensitivity depends on _OS_ filesystem sensitivity.
For linux that gives case sensitive table names.
