### PR TITLE
Test that match against error numbers, dates should set en_US locale, ot...

### DIFF
--- a/core/src/test/java/org/eigenbase/test/SqlLimitsTest.java
+++ b/core/src/test/java/org/eigenbase/test/SqlLimitsTest.java
@@ -27,6 +27,7 @@ import org.eigenbase.sql.type.*;
 
 import com.google.common.collect.ImmutableList;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -78,6 +79,12 @@ public class SqlLimitsTest {
    */
   public static List<BasicSqlType> getTypes() {
     return TYPE_LIST;
+  }
+
+  @BeforeClass public static void setUSLocale() {
+    // This ensures numbers in exceptions are printed as in asserts.
+    // For example, 1,000 vs 1 000
+    Locale.setDefault(Locale.US);
   }
 
   @Test public void testPrintLimits() {

--- a/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
@@ -18,6 +18,7 @@
 package org.eigenbase.test;
 
 import java.nio.charset.*;
+import java.util.Locale;
 import java.util.logging.*;
 
 import org.eigenbase.sql.*;
@@ -30,6 +31,7 @@ import net.hydromatic.avatica.Quoting;
 
 import net.hydromatic.optiq.jdbc.ConnectionConfig;
 
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -90,6 +92,12 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   //~ Methods ----------------------------------------------------------------
+
+  @BeforeClass public static void setUSLocale() {
+    // This ensures numbers in exceptions are printed as in asserts.
+    // For example, 1,000 vs 1 000
+    Locale.setDefault(Locale.US);
+  }
 
   @Test public void testMultipleSameAsPass() {
     check(

--- a/core/src/test/java/org/eigenbase/util/UtilTest.java
+++ b/core/src/test/java/org/eigenbase/util/UtilTest.java
@@ -38,6 +38,7 @@ import net.hydromatic.optiq.util.CompositeMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -54,6 +55,12 @@ public class UtilTest {
   }
 
   //~ Methods ----------------------------------------------------------------
+
+  @BeforeClass public static void setUSLocale() {
+    // This ensures numbers in exceptions are printed as in asserts.
+    // For example, 1,000 vs 1 000
+    Locale.setDefault(Locale.US);
+  }
 
   @Test public void testPrintEquals() {
     assertPrintEquals("\"x\"", "x", true);


### PR DESCRIPTION
...herwise error messages and date literals do not match

Several tests compare error messages here and there. When the locale is not en_US, number and date formats might differ.

On my machine `1000` is formatted as `1 000`, while tests expect `1,000`.

I've added `@BeforeTest Locale.setDefaultLocale` so the test can be run in both maven and IDE (works in IDEA)
