### PR TITLE
Use 1 test thread per CPU to avoid thread starvation on dual core CPUs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,8 @@
           <includes>
             <include>net/hydromatic/optiq/test/OptiqSuite.java</include>
           </includes>
-          <threadCount>6</threadCount>
+          <threadCount>1</threadCount>
+          <perCoreThreadCount>true</perCoreThreadCount>
           <parallel>both</parallel>
           <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
         </configuration>


### PR DESCRIPTION
I guess 1 thread per CPU might work better than "6 threads".

On my dual-core macbook late 2008 (2.4Ghz core 2 duo, 2 cores, 2 threads total)  testing with 6 thread takes longer than with 1 per cpu: 9 minutes vs 5 minutes.
