### PR TITLE
jdbc: do not add varchar-to-varchar casts

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/impl/jdbc/JdbcImplementor.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/jdbc/JdbcImplementor.java
@@ -156,6 +156,15 @@ public class JdbcImplementor {
             nodeList.add(
                 new SqlDataTypeSpec(new SqlIdentifier("CHAR", POS),
                     type.getPrecision(), -1, null, null, POS));
+          } else if (type.getSqlTypeName() == SqlTypeName.VARCHAR
+              && call.getOperands().get(0).getType().getSqlTypeName()
+              == SqlTypeName.VARCHAR) {
+            // Don't perform casting from varchar to varchar
+            // This produced things like
+            // CAST("mycolumn" AS VARCHAR(10) CHARACTER SET "ISO-8859-1")
+            //   = 'this value'
+            // which is not always supported, besides being unnecessary
+            return nodeList.get(0);
           } else {
             nodeList.add(toSql(type));
           }

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -1987,6 +1987,25 @@ public class JdbcTest {
             + "deptno=40; E=Employee [empid: 200, deptno: 20, name: Eric]\n");
   }
 
+  @Test
+  public void testVarcharEquals() {
+    OptiqAssert.that()
+        .withModel(FOODMART_MODEL)
+        .query("select \"lname\" from \"customer\" where \"lname\" = 'Nowmer'")
+        .returns("lname=Nowmer\n");
+
+    // lname is declared as VARCHAR(30), comparing it with a string longer
+    // than 30 characters would introduce a cast to the least restrictive
+    // type, thus lname would be cast to a varchar(40) in this case.
+    // These sorts of casts are removed though when constructing the jdbc
+    // sql, since e.g. HSQLDB does not support them.
+    OptiqAssert.that()
+        .withModel(FOODMART_MODEL)
+        .query("select count(*) as c from \"customer\" "
+            + "where \"lname\" = 'this string is longer than 30 characters'")
+        .returns("C=0\n");
+  }
+
   /** Tests the NOT IN operator. Problems arose in code-generation because
    * the column allows nulls. */
   @Test public void testNotIn() {


### PR DESCRIPTION
When using Optiq's jdbc support with a query condition on a varchar column, this sometimes fails because Optiq introduces varchar-to-varchar casts.

For example, using the foodmart sample with hsqldb, performing this query:

```
select "lname" from "customer" 
where "lname" = 'this string is longer than 30 characters'
```

results in this query on hsqldb:

```
SELECT "lname"
FROM "foodmart"."customer"
WHERE CAST("lname" AS VARCHAR(40) CHARACTER SET "ISO-8859-1") = 'this string is longer than 30 characters'
```

which hsqldb does not understand:

```
Caused by: java.sql.SQLSyntaxErrorException: unexpected token: CHARACTER required: ) : line: 3
    at org.hsqldb.jdbc.JDBCUtil.sqlException(Unknown Source)
    at org.hsqldb.jdbc.JDBCUtil.sqlException(Unknown Source)
    at org.hsqldb.jdbc.JDBCStatement.fetchResult(Unknown Source)
    at org.hsqldb.jdbc.JDBCStatement.executeQuery(Unknown Source)
    at org.apache.commons.dbcp.DelegatingStatement.executeQuery(DelegatingStatement.java:208)
    at org.apache.commons.dbcp.DelegatingStatement.executeQuery(DelegatingStatement.java:208)
    at net.hydromatic.optiq.runtime.ResultSetEnumerable.enumerator(ResultSetEnumerable.java:139)
    ... 39 more
```

I actually experienced this problem in the context of HBase Phoenix, which has a similar problems with not understanding cast syntax.

Optiq introduces casts to the least restrictive type (= the longer string), therefore this issue only occurs when comparing with a string longer than the declared type of lname, which is varchar(30).

I guess that these casts have no additional value, especially since they cast to the least restrictive type, and they also obfuscate the generated sql, therefore I would propose to remove them.

The change proposed here fixes the problem and adds a test. It removes the cast in JdbcImplementor, thus when going from RexNodes to SqlNodes, but the cast will still be visible when requesting "explain plan".
