### PR TITLE
Support querying of arrays on JDBC

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/JavaTypeFactoryImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/JavaTypeFactoryImpl.java
@@ -37,6 +37,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.sql.Array;
 import java.util.*;
 
 /**
@@ -104,19 +105,6 @@ public class JavaTypeFactoryImpl
   }
 
   public Type getJavaClass(RelDataType type) {
-    switch (type.getSqlTypeName()) {
-    case ROW:
-      assert type instanceof RelRecordType;
-      if (type instanceof JavaRecordType) {
-        return ((JavaRecordType) type).clazz;
-      } else {
-        return createSyntheticType((RelRecordType) type);
-      }
-    case MAP:
-      return Map.class;
-    case ARRAY:
-      return List.class;
-    }
     if (type instanceof JavaType) {
       JavaType javaType = (JavaType) type;
       return javaType.getJavaClass();
@@ -154,9 +142,24 @@ public class JavaTypeFactoryImpl
       case BINARY:
       case VARBINARY:
         return ByteString.class;
+      case ARRAY:
+        return Array.class;
       case ANY:
         return Object.class;
       }
+    }
+    switch (type.getSqlTypeName()) {
+    case ROW:
+      assert type instanceof RelRecordType;
+      if (type instanceof JavaRecordType) {
+        return ((JavaRecordType) type).clazz;
+      } else {
+        return createSyntheticType((RelRecordType) type);
+      }
+    case MAP:
+      return Map.class;
+    case ARRAY:
+      return List.class;
     }
     return null;
   }

--- a/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
@@ -131,8 +131,9 @@ public abstract class AbstractCursor implements Cursor {
       default:
         throw new AssertionError("bad " + type.representation);
       }
-    case Types.JAVA_OBJECT:
     case Types.ARRAY:
+      return new ArrayAccessor(getter);
+    case Types.JAVA_OBJECT:
     case Types.STRUCT:
     case Types.OTHER: // e.g. map
       if (type.typeName.startsWith("INTERVAL_")) {
@@ -1024,6 +1025,21 @@ public abstract class AbstractCursor implements Cursor {
         return null;
       }
       return SqlFunctions.intervalDayTimeToString(v, range, scale);
+    }
+  }
+
+  /**
+   * Accessor that assumes that the underlying value is an ARRAY;
+   * corresponds to {@link java.sql.Types#ARRAY}.
+   */
+  private static class ArrayAccessor extends AccessorImpl {
+    public ArrayAccessor(Getter getter) {
+      super(getter);
+    }
+
+    @Override
+    public Array getArray() {
+      return (Array) getObject();
     }
   }
 

--- a/core/src/main/java/org/eigenbase/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/eigenbase/sql/type/SqlTypeName.java
@@ -191,6 +191,7 @@ public enum SqlTypeName {
           .put(Types.BOOLEAN, BOOLEAN)
           .put(Types.DISTINCT, DISTINCT)
           .put(Types.STRUCT, STRUCTURED)
+          .put(Types.ARRAY, ARRAY)
           .build();
 
   /**

--- a/core/src/test/java/org/eigenbase/sql/test/SqlTypeNameTest.java
+++ b/core/src/test/java/org/eigenbase/sql/test/SqlTypeNameTest.java
@@ -249,8 +249,8 @@ public class SqlTypeNameTest {
     SqlTypeName tn =
         SqlTypeName.getNameForJdbcType(Types.ARRAY);
     assertEquals(
-        "ARRAY did not map to null",
-        null,
+        "ARRAY did not map to ARRAY",
+        SqlTypeName.ARRAY,
         tn);
   }
 


### PR DESCRIPTION
Please consider this change to allow querying java.sql.Arrays on underlying JDBC connections through Optiq (currently trying to query an array via Optiq results in a NullPointerException).

I've included a test in JdbcTest which opens its own connection to an in-memory HSQLDB to test array functionality to not alter the foodmart schema at all. All tests pass with this patch applied.
