### PR TITLE
Fixed the mongo-zips-model.json link

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -69,7 +69,7 @@ connecting to: test
 bye
 ```
 
-Connect using the <a href="src/test/resources/mongo-zips-model.json">mongo-zips-model.json</a> Optiq model:
+Connect using the <a href="https://github.com/julianhyde/optiq/blob/master/mongodb/src/test/resources/mongo-zips-model.json">mongo-zips-model.json</a> Optiq model:
 ```bash
 $ ./sqlline
 sqlline> !connect jdbc:optiq:model=mongodb/target/test-classes/mongo-zips-model.json admin admin


### PR DESCRIPTION
Julian, the link from the HowTo to the Optiq model for the Mongo Zips Collection was broken, just changed it to point it to the current  location of the file in the master branch. Also used an absolute link so it can be followed outside gitHub.
