### PR TITLE
Add clear() to RelOptPlanner. PlannerImpl.transform() call clear().

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
@@ -190,6 +190,7 @@ public class PlannerImpl implements Planner {
     ensure(State.STATE_5_CONVERTED);
     RuleSet ruleSet = ruleSets.get(ruleSetIndex);
     planner.clearRules();
+    planner.clear();
     for (RelOptRule rule : ruleSet) {
       planner.addRule(rule);
     }

--- a/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
@@ -73,6 +73,8 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   //~ Methods ----------------------------------------------------------------
 
+  public void clear() {}
+
   public RelOptCostFactory getCostFactory() {
     return costFactory;
   }

--- a/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
@@ -74,6 +74,11 @@ public interface RelOptPlanner {
   void clearRules();
 
   /**
+   * Remove all internal status of planner.
+   */
+  void clear();
+
+  /**
    * Registers a rule. If the rule has already been registered, does nothing.
    * This method should determine if the given rule is a {@link
    * org.eigenbase.rel.convert.ConverterRule} and pass the ConverterRule to

--- a/core/src/main/java/org/eigenbase/relopt/volcano/RuleQueue.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/RuleQueue.java
@@ -121,6 +121,13 @@ class RuleQueue {
   }
 
   //~ Methods ----------------------------------------------------------------
+  /**
+   * Clear internal data structure for this rule queue.
+   */
+  public void clear() {
+    this.subsetImportances.clear();
+    this.boostedSubsets.clear();
+  }
 
   /**
    * Removes the {@link PhaseMatchList rule-match list} for the given planner

--- a/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
@@ -1697,6 +1697,15 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     pop(ruleCallStack, ruleCall);
   }
 
+  public void clear() {
+    this.allOperands.clear();
+    this.allSets.clear();
+    this.mapDigestToRel.clear();
+    this.mapRel2Subset.clear();
+    this.relImportances.clear();
+    this.ruleQueue.clear();
+  }
+
   //~ Inner Classes ----------------------------------------------------------
 
   /**


### PR DESCRIPTION
Hi Julian,

This is the code we modified in optiq, to address the issue when developing code in Apache Drill. Specifically, when Drill wants to call planner.transform() multiple times, each with different rulesets and different conventions, optiq might throw CanNotPlanException during the second call, because it still has the status from the first call of transform().  

I added a unit test case in PlannerTest:testPlanTransformWithDiffRulesetAndConvention(). This testcase will fail with CanNotPlanException, if we comment out the line of planner.clear() in PlannerImpl.transform() method.  

Please take a look and see if there is any problem in the fix. Thanks a lot! 

BTW: Originally, the issue was reported in issue #162. But it was accidentally closed, because I deleted my local branch. 
