### PR TITLE
Use subsumes to replace equal check in an assert check in VolcanoPlanner...

### DIFF
--- a/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
@@ -981,7 +981,8 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
               toTrait,
               allowInfiniteCostConverters);
       if (rel != null) {
-        assert rel.getTraitSet().contains(toTrait);
+        assert rel.getTraitSet().getTrait(toTrait.getTraitDef()).
+            subsumes(toTrait);
         rel =
             completeConversion(
                 rel, allowInfiniteCostConverters, toTraits,


### PR DESCRIPTION
In VolcanoPlanner.changeTraitsUsingConverters(), the code uses equal to check if the converted RelNode has the required trait.

if (rel != null) {
        assert rel.getTraitSet().contains(toTrait);
        ....
}

This assert check should in stead use subsumes(), since as long as the converted RelNode's trait subsumes toTrait, it would be good enough to have this converted RelNode.

Please take a look to see if there is any issue for this fix. 
