### PR TITLE
Add a way to specify list of TraitDefs that will be used by planner when...

### DIFF
--- a/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
@@ -214,6 +214,9 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
     return false;
   }
 
+  // implement RelOptPlanner
+  public void clearRelTraitDefs() {}
+
   public List<RelTraitDef> getRelTraitDefs() {
     return Collections.emptyList();
   }

--- a/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
@@ -64,6 +64,11 @@ public interface RelOptPlanner {
   boolean addRelTraitDef(RelTraitDef relTraitDef);
 
   /**
+   * Clear all the registered RelTraitDef.
+   */
+  void clearRelTraitDefs();
+
+  /**
    * Returns the list of active trait types.
    */
   List<RelTraitDef> getRelTraitDefs();

--- a/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
@@ -411,6 +411,11 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   }
 
   @Override
+  public void clearRelTraitDefs() {
+    traitDefs.clear();
+  }
+
+  @Override
   public List<RelTraitDef> getRelTraitDefs() {
     return traitDefs;
   }


### PR DESCRIPTION
Hi Julian,

This is the code change to support user to explicitly specify the list of RelTraitDef to register with VolcalnoPlanner, when user call Frameworks.getPlanner().  If user provides such list, then, the planner will de-register any existing RelTraitDef, before register the RelTraitDef in the provided list. 

This code change has two purposes. 1) User could specify the list of RelTraitDef, 2) User could specify the order of importance of each RelTraitDef.  (The order of importance will determine the sequence call of RelTraitDef.convert() in VolcalnoPlanner.changeTraitsUsingConvert() method. ) 

I also added a unit test case in PlannerTest:testPlanWithExplicitTraitDefs().  This test is almost same as PlannerTest:testPlan(), except the former uses an explicitly specified list of RelTraitDef, when creates the planner. 
