### PR TITLE
Add Phoenix (HBase) SQL dialect

### DIFF
--- a/core/src/main/java/org/eigenbase/sql/SqlDialect.java
+++ b/core/src/main/java/org/eigenbase/sql/SqlDialect.java
@@ -162,6 +162,8 @@ public class SqlDialect {
       return DatabaseProduct.PARACCEL;
     } else if (productName.equals("Oracle")) {
       return DatabaseProduct.ORACLE;
+    } else if (productName.equals("Phoenix")) {
+      return DatabaseProduct.PHOENIX;
     } else if (upperProductName.contains("POSTGRE")) {
       return DatabaseProduct.POSTGRESQL;
     } else if (upperProductName.contains("NETEZZA")) {
@@ -405,6 +407,7 @@ public class SqlDialect {
     switch (databaseProduct) {
     case MYSQL:
     case HSQLDB:
+    case PHOENIX:
       return false;
     default:
       return true;
@@ -482,6 +485,7 @@ public class SqlDialect {
     INGRES("Ingres", null),
     LUCIDDB("LucidDB", "\""),
     INTERBASE("Interbase", null),
+    PHOENIX("Phoenix", "\""),
     POSTGRESQL("PostgreSQL", "\""),
     NETEZZA("Netezza", "\""),
     INFOBRIGHT("Infobright", "`"),


### PR DESCRIPTION
Like mysql/hsqldb, Phoenix does not support charsets in casts.
