### PR TITLE
Rework calendar handling for time-based cols

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/impl/jdbc/JdbcToEnumerableConverter.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/jdbc/JdbcToEnumerableConverter.java
@@ -182,7 +182,8 @@ public class JdbcToEnumerableConverter
       dateTimeArgs.add(calendar_);
       break;
     case NULL:
-      dateTimeArgs.add(Expressions.constant(null));
+      // We don't specify a calendar at all, so we don't add an argument and
+      // instead use the version of the getXXX that doesn't take a Calendar
       break;
     case DIRECT:
       sqlTypeName = SqlTypeName.ANY;

--- a/core/src/main/java/net/hydromatic/optiq/runtime/SqlFunctions.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/SqlFunctions.java
@@ -48,6 +48,8 @@ public class SqlFunctions {
   /** The julian date of the epoch, 1970-01-01. */
   public static final int EPOCH_JULIAN = 2440588;
 
+  private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
   private SqlFunctions() {
   }
 
@@ -868,7 +870,7 @@ public class SqlFunctions {
   }
 
   public static int toInt(java.util.Date v) {
-    return (int) (v.getTime() / DateTimeUtil.MILLIS_PER_DAY);
+    return toInt(v, LOCAL_TZ);
   }
 
   public static int toInt(java.util.Date v, TimeZone timeZone) {
@@ -876,21 +878,21 @@ public class SqlFunctions {
   }
 
   public static Integer toIntOptional(java.util.Date v) {
-    return v == null ? null : (int) (v.getTime() / DateTimeUtil.MILLIS_PER_DAY);
+    return v == null ? null : toInt(v);
   }
 
   public static Integer toIntOptional(java.util.Date v, TimeZone timeZone) {
     return v == null
         ? null
-        : (int) (toLong(v, timeZone) / DateTimeUtil.MILLIS_PER_DAY);
+        : toInt(v, timeZone);
   }
 
   public static int toInt(java.sql.Time v) {
-    return (int) (v.getTime() % DateTimeUtil.MILLIS_PER_DAY);
+    return (int) (toLong(v) % DateTimeUtil.MILLIS_PER_DAY);
   }
 
   public static Integer toIntOptional(java.sql.Time v) {
-    return v == null ? null : (int) (v.getTime() % DateTimeUtil.MILLIS_PER_DAY);
+    return v == null ? null : toInt(v);
   }
 
   public static int toInt(String s) {
@@ -909,7 +911,7 @@ public class SqlFunctions {
   }
 
   public static long toLong(Timestamp v) {
-    return v.getTime();
+    return toLong(v, LOCAL_TZ);
   }
 
   // mainly intended for java.sql.Timestamp but works for other dates also
@@ -920,15 +922,14 @@ public class SqlFunctions {
 
   // mainly intended for java.sql.Timestamp but works for other dates also
   public static Long toLongOptional(java.util.Date v) {
-    return v == null ? null : v.getTime();
+    return v == null ? null : toLong(v, LOCAL_TZ);
   }
 
   public static Long toLongOptional(Timestamp v, TimeZone timeZone) {
     if (v == null) {
       return null;
     }
-    final long time = v.getTime();
-    return time + timeZone.getOffset(time);
+    return toLong(v, LOCAL_TZ);
   }
 
   public static long toLong(String s) {

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.*;
+import java.sql.Date;
 import java.sql.Statement;
 import java.util.*;
 import javax.sql.DataSource;
@@ -3255,6 +3256,62 @@ public class JdbcTest {
     ++c;
 
     assertTrue(!rs.next());
+  }
+
+  /** Tests accessing a column in a JDBC source whose type is DATE. */
+  @Test
+  public void testGetDate() throws Exception {
+    OptiqAssert.that()
+      .with(OptiqAssert.Config.JDBC_FOODMART)
+      .doWithConnection(new Function1<OptiqConnection, Object>() {
+        public Object apply(OptiqConnection conn) {
+          try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(
+              "select min(\"date\") mindate from \"foodmart\".\"currency\"");
+            assertTrue(rs.next());
+            assertEquals(
+              Date.valueOf("1997-01-01"),
+              rs.getDate(1));
+            assertFalse(rs.next());
+            return null;
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
+  }
+
+  /** Tests accessing a date as a string in a JDBC source whose type is DATE. */
+  @Test
+  public void testGetDateAsString() throws Exception {
+    OptiqAssert.that()
+      .with(OptiqAssert.Config.JDBC_FOODMART)
+      .query("select min(\"date\") mindate from \"foodmart\".\"currency\"")
+      .returns("MINDATE=1997-01-01\n");
+  }
+
+  @Test
+  public void testGetTimestampObject() throws Exception {
+    OptiqAssert.that()
+      .with(OptiqAssert.Config.JDBC_FOODMART)
+      .doWithConnection(new Function1<OptiqConnection, Object>() {
+        public Object apply(OptiqConnection conn) {
+          try {
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(
+              "select \"hire_date\" from \"foodmart\".\"employee\" where \"employee_id\" = 1");
+            assertTrue(rs.next());
+            assertEquals(
+              Timestamp.valueOf("1994-12-01 00:00:00"),
+              rs.getTimestamp(1));
+            assertFalse(rs.next());
+            return null;
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        }
+      });
   }
 
   @Test public void testUnicode() throws Exception {


### PR DESCRIPTION
This change makes is so that ResultSet#getDate(int) (and getTimestamp and getTime) is called on an underlying JDBC connection if no custom calendar is available, instead of calling ResultSet#getDate(int, Calendar) with a null Calendar (the latter causes NPEs in Phoenix, and possibly other JDBC drivers).

In order to get this working, I had to make a number of changes to the OptiqAssert framework as well to allow supplying a custom Calendar. It seems that the HSQLDB ResultSet performs quite differently if you use getTimestamp(int) compared to getTimestamp(int, null). It seems like it would be more ideal to not make the changes to OptiqAssert, but I wasn't able to find a way around it (I'm assuming that this is a bug in HSQLDB).
