### PR TITLE
Use RexExecutor to evaluate projections and filters

### DIFF
--- a/core/src/main/java/org/eigenbase/rel/rules/ReduceExpressionsRule.java
+++ b/core/src/main/java/org/eigenbase/rel/rules/ReduceExpressionsRule.java
@@ -324,7 +324,7 @@ public abstract class ReduceExpressionsRule extends RelOptRule {
     RelOptPlanner.Executor executor =
         rel.getCluster().getPlanner().getExecutor();
     List<RexNode> reducedValues = new ArrayList<RexNode>();
-    executor.execute(rexBuilder, constExps, reducedValues);
+    executor.reduce(rexBuilder, constExps, reducedValues);
 
     // For ProjectRel, we have to be sure to preserve the result
     // types, so always cast regardless of the expression type.

--- a/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
@@ -284,7 +284,7 @@ public interface RelOptPlanner {
     /**
      * Reduces expressions, and writes their results into {@code reducedValues}.
      */
-    void execute(RexBuilder rexBuilder, List<RexNode> constExps,
+    void reduce(RexBuilder rexBuilder, List<RexNode> constExps,
         List<RexNode> reducedValues);
   }
 

--- a/core/src/main/java/org/eigenbase/rex/RexExecutable.java
+++ b/core/src/main/java/org/eigenbase/rex/RexExecutable.java
@@ -1,0 +1,94 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.rex;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eigenbase.util.Pair;
+
+import net.hydromatic.linq4j.function.Function1;
+
+import net.hydromatic.optiq.DataContext;
+import net.hydromatic.optiq.runtime.Hook;
+import net.hydromatic.optiq.runtime.Utilities;
+
+import org.codehaus.commons.compiler.CompileException;
+import org.codehaus.janino.ClassBodyEvaluator;
+import org.codehaus.janino.Scanner;
+
+
+
+/**
+ * Contains executable code from {@link RexNode} expression.
+ */
+public class RexExecutable {
+  public static final String GENERATED_CLASS_NAME = "Reducer";
+
+  Function1<DataContext, Object[]> compiledFunction;
+  private final String generatedCode;
+  private DataContext dataContext;
+  private final RexBuilder rexBuilder;
+
+  public RexExecutable(String genCode, RexBuilder rexBuilder) {
+    try {
+      compiledFunction = (Function1) ClassBodyEvaluator
+          .createFastClassBodyEvaluator(new Scanner(null, new StringReader(
+              genCode)), GENERATED_CLASS_NAME, Utilities.class, new Class[] {
+                Function1.class, Serializable.class
+              }, getClass()
+              .getClassLoader());
+    } catch (CompileException e) {
+      throw new RuntimeException("While compiling generated Rex code", e);
+    } catch (IOException e) {
+      throw new RuntimeException("While compiling generated Rex code", e);
+    }
+    this.rexBuilder = rexBuilder;
+    this.generatedCode = genCode;
+  }
+
+  public void setDataContext(DataContext dataContext) {
+    this.dataContext = dataContext;
+  }
+
+  public void reduce(List<RexNode> constExps, List<RexNode> reducedValues) {
+    Object[] values = compiledFunction.apply(dataContext);
+    assert values.length == constExps.size();
+    final List<Object> valueList = Arrays.asList(values);
+    for (Pair<RexNode, Object> value : Pair.zip(constExps, valueList)) {
+      reducedValues.add(rexBuilder.makeLiteral(value.right,
+          value.left.getType(), true));
+    }
+    Hook.EXPRESSION_REDUCER.run(Pair.of(generatedCode, values));
+  }
+
+  public Function1<DataContext, Object[]> getFunction() {
+    return compiledFunction;
+  }
+
+  public Object[] execute() {
+    return compiledFunction.apply(dataContext);
+  }
+
+  public String getSource() {
+    return generatedCode;
+  }
+}

--- a/core/src/main/java/org/eigenbase/rex/RexExecutorImpl.java
+++ b/core/src/main/java/org/eigenbase/rex/RexExecutorImpl.java
@@ -35,6 +35,7 @@ import net.hydromatic.optiq.DataContext;
 import net.hydromatic.optiq.jdbc.JavaTypeFactoryImpl;
 import net.hydromatic.optiq.prepare.OptiqPrepareImpl;
 import net.hydromatic.optiq.rules.java.RexToLixTranslator;
+import net.hydromatic.optiq.rules.java.RexToLixTranslator.InputGetter;
 import net.hydromatic.optiq.runtime.*;
 
 import com.google.common.collect.ImmutableList;
@@ -47,12 +48,6 @@ import org.codehaus.janino.Scanner;
 * Evaluates a {@link RexNode} expression.
 */
 public class RexExecutorImpl implements RelOptPlanner.Executor {
-  private static final RexToLixTranslator.InputGetter BAD_GETTER =
-      new RexToLixTranslator.InputGetter() {
-        public Expression field(BlockBuilder list, int index) {
-          throw new UnsupportedOperationException();
-        }
-      };
 
   private final DataContext dataContext;
 
@@ -60,12 +55,16 @@ public class RexExecutorImpl implements RelOptPlanner.Executor {
     this.dataContext = dataContext;
   }
 
-  public void execute(RexBuilder rexBuilder, List<RexNode> constExps,
-      List<RexNode> reducedValues) {
+  private String compile(RexBuilder rexBuilder, List<RexNode> constExps,
+      RexToLixTranslator.InputGetter getter) {
     final RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
     final RelDataType emptyRowType = typeFactory.builder().build();
+    return compile(rexBuilder, constExps, getter, emptyRowType);
+  }
+  private String compile(RexBuilder rexBuilder, List<RexNode> constExps,
+      RexToLixTranslator.InputGetter getter, RelDataType rowType) {
     final RexProgramBuilder programBuilder =
-        new RexProgramBuilder(emptyRowType, rexBuilder);
+        new RexProgramBuilder(rowType, rexBuilder);
     for (RexNode node : constExps) {
       programBuilder.addProject(
           node, "c" + programBuilder.getProjectList().size());
@@ -81,7 +80,7 @@ public class RexExecutorImpl implements RelOptPlanner.Executor {
             Expressions.convert_(root0_, DataContext.class)));
     final List<Expression> expressions =
         RexToLixTranslator.translateProjects(programBuilder.getProgram(),
-        javaTypeFactory, blockBuilder, BAD_GETTER);
+        javaTypeFactory, blockBuilder, getter);
     blockBuilder.add(
         Expressions.return_(null,
             Expressions.newArrayInit(Object[].class, expressions)));
@@ -89,15 +88,59 @@ public class RexExecutorImpl implements RelOptPlanner.Executor {
         Expressions.methodDecl(Modifier.PUBLIC, Object[].class,
             BuiltinMethod.FUNCTION1_APPLY.method.getName(),
             ImmutableList.of(root0_), blockBuilder.toBlock());
-    String s = Expressions.toString(methodDecl);
+    String code = Expressions.toString(methodDecl);
     if (OptiqPrepareImpl.DEBUG) {
-      System.out.println(s);
+      System.out.println(code);
     }
+    return code;
+  }
+
+  /**
+   * creates an {@link RexExecutable} that allows to apply the
+   * generated code during query processing (filter, projection).
+   *
+   * @param rowType describes the structure of the input row.
+   */
+  public RexExecutable getExecutable(final RexBuilder rexBuilder,
+      List<RexNode> constExps, final RelDataType rowType) {
+    InputGetter getter =  new RexToLixTranslator.InputGetter() {
+      final JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl();
+      public Expression field(BlockBuilder list, int index) {
+        MethodCallExpression recFromCtx = Expressions.call(
+            DataContext.ROOT,
+            BuiltinMethod.DATA_CONTEXT_GET.method,
+            Expressions.constant("inputRecord"));
+        Expression recFromCtxCasted =
+            RexToLixTranslator.convert(recFromCtx, Object[].class);
+        IndexExpression recordAccess = Expressions.arrayIndex(recFromCtxCasted,
+            Expressions.constant(index));
+        return RexToLixTranslator.convert(recordAccess,
+            typeFactory.getJavaClass(rowType.getFieldList().get(index)
+                .getType()));
+      }
+    };
+
+    final String code = compile(rexBuilder, constExps, getter, rowType);
+    return new RexExecutable(code, rexBuilder);
+  }
+
+  /**
+   * Do constant reduction using generated code
+   */
+  public void reduce(RexBuilder rexBuilder, List<RexNode> constExps,
+      List<RexNode> reducedValues) {
+    final String code = compile(rexBuilder, constExps,
+        new RexToLixTranslator.InputGetter() {
+          public Expression field(BlockBuilder list, int index) {
+            throw new UnsupportedOperationException();
+          }
+        });
+
     try {
       //noinspection unchecked
       Function1<DataContext, Object[]> function =
           (Function1) ClassBodyEvaluator.createFastClassBodyEvaluator(
-              new Scanner(null, new StringReader(s)),
+              new Scanner(null, new StringReader(code)),
               "Reducer",
               Utilities.class,
               new Class[]{Function1.class},
@@ -109,7 +152,7 @@ public class RexExecutorImpl implements RelOptPlanner.Executor {
         reducedValues.add(
             rexBuilder.makeLiteral(value.right, value.left.getType(), true));
       }
-      Hook.EXPRESSION_REDUCER.run(Pair.of(s, values));
+      Hook.EXPRESSION_REDUCER.run(Pair.of(code, values));
     } catch (CompileException e) {
       throw new RuntimeException("While evaluating " + constExps, e);
     } catch (IOException e) {


### PR DESCRIPTION
Hi,

I was asking on the mailing list if there is a way to use the existing code-generation infrastructure to evaluate projections and filters: https://groups.google.com/forum/#!topic/optiq-dev/-97ONPmDTB4.

This pull request contains my first approach to change the Rex\* components to allow that.

My change includes the following:
- Decoupling of code generation, compilation and execution (to allow efficient execution). I therefore introduced the `RexExecutable` class that allows to `reduce()` and `execute()` (given a DataContext)
- I also changed the `DataContext` interface to allow direct access (using an int-index) to the data (instead of using a HashMap)
- The most important change is that I introduced a `isExternal`-flag on the `RexInputRef` which indicates that the Ref refers to a variable accessible from the DataContext.

I'm very happy about any feedback regarding my pull request. I know its certainly not the cleanest approach to implement this feature. But I didn't want to spend too much time working on it without any feedback. (Maybe adding something like a `RexContextRef` is cleaner? (I probably have to shuttle through replacing all InputRefs by RexContextRefs then))

I know that the pull request is a bit messed up (4 commits and I accidentally changed some code formattings while working with (/fighting against) the checkstyle plugin. Once I got feedback, I'll clean those things up and update the PR (using force push).
