### PR TITLE
Use Pair<String, String> instead of String concatenation to reduce garba...

### DIFF
--- a/core/src/main/java/org/eigenbase/rel/rules/ReduceDecimalsRule.java
+++ b/core/src/main/java/org/eigenbase/rel/rules/ReduceDecimalsRule.java
@@ -112,13 +112,13 @@ public class ReduceDecimalsRule extends RelOptRule {
    * longs.
    */
   public class DecimalShuttle extends RexShuttle {
-    private final Map<String, RexNode> irreducible;
-    private final Map<String, RexNode> results;
+    private final Map<Pair<String, String>, RexNode> irreducible;
+    private final Map<Pair<String, String>, RexNode> results;
     private final ExpanderMap expanderMap;
 
     public DecimalShuttle(RexBuilder rexBuilder) {
-      irreducible = new HashMap<String, RexNode>();
-      results = new HashMap<String, RexNode>();
+      irreducible = new HashMap<Pair<String, String>, RexNode>();
+      results = new HashMap<Pair<String, String>, RexNode>();
       expanderMap = new ExpanderMap(rexBuilder);
     }
 
@@ -163,7 +163,7 @@ public class ReduceDecimalsRule extends RelOptRule {
      * Registers node so it will not be computed again
      */
     private void register(RexNode node, RexNode reducedNode) {
-      String key = RexUtil.makeKey(node);
+      Pair<String, String> key = RexUtil.makeKey(node);
       if (node == reducedNode) {
         irreducible.put(key, reducedNode);
       } else {
@@ -175,7 +175,7 @@ public class ReduceDecimalsRule extends RelOptRule {
      * Lookup registered node
      */
     private RexNode lookup(RexNode node) {
-      String key = RexUtil.makeKey(node);
+      Pair<String, String> key = RexUtil.makeKey(node);
       if (irreducible.get(key) != null) {
         return node;
       }

--- a/core/src/main/java/org/eigenbase/rex/RexProgramBuilder.java
+++ b/core/src/main/java/org/eigenbase/rex/RexProgramBuilder.java
@@ -37,8 +37,8 @@ public class RexProgramBuilder {
   private final RexBuilder rexBuilder;
   private final RelDataType inputRowType;
   private final List<RexNode> exprList = new ArrayList<RexNode>();
-  private final Map<String, RexLocalRef> exprMap =
-      new HashMap<String, RexLocalRef>();
+  private final Map<Pair<String, String>, RexLocalRef> exprMap =
+      new HashMap<Pair<String, String>, RexLocalRef>();
   private final List<RexLocalRef> localRefList = new ArrayList<RexLocalRef>();
   private final List<RexLocalRef> projectRefList =
       new ArrayList<RexLocalRef>();
@@ -298,10 +298,13 @@ public class RexProgramBuilder {
    *              sub-expression exists.
    */
   private RexLocalRef registerInternal(RexNode expr, boolean force) {
-    String key = RexUtil.makeKey(expr);
-    RexLocalRef ref = exprMap.get(key);
-    if ((ref == null) && (expr instanceof RexLocalRef)) {
+    RexLocalRef ref;
+    Pair<String, String> key = null;
+    if (expr instanceof RexLocalRef) {
       ref = (RexLocalRef) expr;
+    } else {
+      key = RexUtil.makeKey(expr);
+      ref = exprMap.get(key);
     }
     if (ref == null) {
       if (validating) {

--- a/core/src/main/java/org/eigenbase/rex/RexUtil.java
+++ b/core/src/main/java/org/eigenbase/rex/RexUtil.java
@@ -537,11 +537,8 @@ public class RexUtil {
    * representation. For example, "10" integer and "10" bigint result in
    * different keys.
    */
-  public static String makeKey(RexNode expr) {
-    String type = expr.getType().getFullTypeString();
-    String separator = ";";
-    String node = expr.toString();
-    return type + separator + node;
+  public static Pair<String, String> makeKey(RexNode expr) {
+    return Pair.of(expr.toString(), expr.getType().getFullTypeString());
   }
 
   /**


### PR DESCRIPTION
...ge when searching in Rex expr caches

Avoid string concatenation when canonizing expressions in `RexProgramBuilder`.
At best we should avoid `Map` altogether (especially when `ProgramBuilder` is created for a known program just to optimize it), however `Pair<String, String>` key will be simpler for creation, hash code check and comparison (i.e. `String` instances will cache their hashCodes, etc)

The assumption is `expr.toString()` and `expr.getType().getFullTypeString()` are garbage-free (those methods just return already existing fields)
