### PR TITLE
Avoid creation of stacktrace for internally-used-for-control-flow except...

### DIFF
--- a/core/src/main/java/org/eigenbase/util/Util.java
+++ b/core/src/main/java/org/eigenbase/util/Util.java
@@ -2090,6 +2090,11 @@ public class Util {
     public Object getNode() {
       return node;
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      return this;
+    }
   }
 }
 


### PR DESCRIPTION
...ion.

This improves exception construction speed.
