### PR TITLE
fix javadoc for java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,5 +287,23 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <profiles />
+  <profiles>
+  <profile>
+    <id>docline-java8-disable</id>
+    <activation>
+      <jdk>[1.8,</jdk>
+    </activation>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+</profiles>
 </project>


### PR DESCRIPTION
Fix issue https://github.com/julianhyde/optiq/issues/200.

I think we had the same problem in our project: https://github.com/stratosphere/stratosphere/pull/549 and solved it as described here: http://stackoverflow.com/a/22296107/568695 using Maven build profiles.
