### PR TITLE
Extend extract function to support DateTime data types

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
@@ -53,6 +53,7 @@ import org.eigenbase.sql.type.*;
 import org.eigenbase.sql.util.ChainedSqlOperatorTable;
 import org.eigenbase.sql.validate.*;
 import org.eigenbase.sql2rel.SqlToRelConverter;
+import org.eigenbase.sql2rel.StandardConvertletTable;
 import org.eigenbase.util.Util;
 
 import com.google.common.collect.*;
@@ -601,7 +602,8 @@ public class OptiqPrepareImpl implements OptiqPrepare {
         CatalogReader catalogReader) {
       SqlToRelConverter sqlToRelConverter =
           new SqlToRelConverter(
-              this, validator, catalogReader, planner, rexBuilder);
+              this, validator, catalogReader, planner, rexBuilder,
+              StandardConvertletTable.INSTANCE);
       sqlToRelConverter.setTrimUnusedFields(false);
       return sqlToRelConverter;
     }

--- a/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
@@ -34,6 +34,7 @@ import org.eigenbase.sql.SqlOperatorTable;
 import org.eigenbase.sql.parser.SqlParseException;
 import org.eigenbase.sql.parser.SqlParser;
 import org.eigenbase.sql.parser.SqlParserImplFactory;
+import org.eigenbase.sql2rel.SqlRexConvertletTable;
 import org.eigenbase.sql2rel.SqlToRelConverter;
 
 import com.google.common.collect.ImmutableList;
@@ -73,6 +74,7 @@ public class PlannerImpl implements Planner {
 
   // set in STATE_5_CONVERT
   private SqlToRelConverter sqlToRelConverter;
+  private SqlRexConvertletTable convertletTable;
   private RelNode rel;
 
   /** Creates a planner. Not a public API; call
@@ -80,7 +82,8 @@ public class PlannerImpl implements Planner {
   public PlannerImpl(Lex lex, SqlParserImplFactory parserFactory,
       Function1<SchemaPlus, Schema> schemaFactory,
       SqlOperatorTable operatorTable, ImmutableList<RuleSet> ruleSets,
-      ImmutableList<RelTraitDef> traitDefs) {
+      ImmutableList<RelTraitDef> traitDefs,
+      SqlRexConvertletTable convertletTable) {
     this.schemaFactory = schemaFactory;
     this.operatorTable = operatorTable;
     this.ruleSets = ruleSets;
@@ -88,6 +91,7 @@ public class PlannerImpl implements Planner {
     this.parserFactory = parserFactory;
     this.state = State.STATE_0_CLOSED;
     this.traitDefs = traitDefs;
+    this.convertletTable = convertletTable;
     reset();
   }
 
@@ -204,7 +208,7 @@ public class PlannerImpl implements Planner {
     this.sqlToRelConverter =
         new SqlToRelConverter(
             null, validator, createCatalogReader(), planner,
-            createRexBuilder());
+            createRexBuilder(), convertletTable);
     sqlToRelConverter.setTrimUnusedFields(false);
     rel = sqlToRelConverter.convertQuery(validatedSqlNode, false, true);
     state = State.STATE_5_CONVERTED;

--- a/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
@@ -74,7 +74,7 @@ public class Frameworks {
       Function1<SchemaPlus, Schema> schemaFactory,
       SqlOperatorTable operatorTable, RuleSet... ruleSets) {
     return getPlanner(lex, SqlParserImpl.FACTORY, schemaFactory,
-        operatorTable, null, ruleSets);
+        operatorTable, null, StandardConvertletTable.INSTANCE, ruleSets);
   }
 
   /**
@@ -114,16 +114,6 @@ public class Frameworks {
       Function1<SchemaPlus, Schema> schemaFactory,
       SqlOperatorTable operatorTable,
       List<RelTraitDef> traitDefs,
-      RuleSet... ruleSets) {
-    return getPlanner(lex, parserFactory, schemaFactory, operatorTable,
-             traitDefs, new StandardConvertletTable(), ruleSets);
-  }
-
-  public static Planner getPlanner(Lex lex,
-      SqlParserImplFactory parserFactory,
-      Function1<SchemaPlus, Schema> schemaFactory,
-      SqlOperatorTable operatorTable,
-      List<RelTraitDef> traitDefs,
       SqlRexConvertletTable convertletTable,
       RuleSet... ruleSets) {
 
@@ -135,7 +125,7 @@ public class Frameworks {
 
 
 
-    /** Piece of code to be run in a context where a planner is available. The
+  /** Piece of code to be run in a context where a planner is available. The
    * planner is accessible from the {@code cluster} parameter, as are several
    * other useful objects. */
   public interface PlannerAction<R> {

--- a/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
@@ -33,6 +33,8 @@ import org.eigenbase.relopt.RelTraitDef;
 import org.eigenbase.sql.SqlOperatorTable;
 import org.eigenbase.sql.parser.SqlParserImplFactory;
 import org.eigenbase.sql.parser.impl.SqlParserImpl;
+import org.eigenbase.sql2rel.SqlRexConvertletTable;
+import org.eigenbase.sql2rel.StandardConvertletTable;
 
 import com.google.common.collect.ImmutableList;
 
@@ -113,12 +115,27 @@ public class Frameworks {
       SqlOperatorTable operatorTable,
       List<RelTraitDef> traitDefs,
       RuleSet... ruleSets) {
-    return new PlannerImpl(lex, parserFactory, schemaFactory, operatorTable,
-        ImmutableList.copyOf(ruleSets),
-        traitDefs == null ? null : ImmutableList.copyOf(traitDefs));
+    return getPlanner(lex, parserFactory, schemaFactory, operatorTable,
+             traitDefs, new StandardConvertletTable(), ruleSets);
   }
 
-  /** Piece of code to be run in a context where a planner is available. The
+  public static Planner getPlanner(Lex lex,
+      SqlParserImplFactory parserFactory,
+      Function1<SchemaPlus, Schema> schemaFactory,
+      SqlOperatorTable operatorTable,
+      List<RelTraitDef> traitDefs,
+      SqlRexConvertletTable convertletTable,
+      RuleSet... ruleSets) {
+
+    return new PlannerImpl(lex, parserFactory, schemaFactory, operatorTable,
+        ImmutableList.copyOf(ruleSets),
+        traitDefs == null ? null : ImmutableList.copyOf(traitDefs),
+        convertletTable);
+  }
+
+
+
+    /** Piece of code to be run in a context where a planner is available. The
    * planner is accessible from the {@code cluster} parameter, as are several
    * other useful objects. */
   public interface PlannerAction<R> {

--- a/core/src/main/java/org/eigenbase/sql/fun/SqlExtractFunction.java
+++ b/core/src/main/java/org/eigenbase/sql/fun/SqlExtractFunction.java
@@ -38,7 +38,7 @@ public class SqlExtractFunction extends SqlFunction {
         SqlKind.OTHER_FUNCTION,
         ReturnTypes.BIGINT_NULLABLE,
         null,
-        OperandTypes.INTERVAL_SAME_SAME,
+        OperandTypes.INTERVALINTERVAL_INTERVALDATETIME,
         SqlFunctionCategory.SYSTEM);
   }
 

--- a/core/src/main/java/org/eigenbase/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/eigenbase/sql/type/OperandTypes.java
@@ -310,6 +310,10 @@ public abstract class OperandTypes {
   public static final SqlSingleOperandTypeChecker INTERVAL_DATETIME =
       family(SqlTypeFamily.DATETIME_INTERVAL, SqlTypeFamily.DATETIME);
 
+  public static final SqlSingleOperandTypeChecker
+  INTERVALINTERVAL_INTERVALDATETIME =
+      OperandTypes.or(INTERVAL_SAME_SAME, INTERVAL_DATETIME);
+
   // TODO: datetime+interval checking missing
   // TODO: interval+datetime checking missing
   public static final SqlSingleOperandTypeChecker PLUS_OPERATOR =

--- a/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
@@ -144,6 +144,26 @@ public class SqlToRelConverter {
       Prepare.CatalogReader catalogReader,
       RelOptPlanner planner,
       RexBuilder rexBuilder) {
+      this(viewExpander, validator, catalogReader, planner, rexBuilder,
+        new StandardConvertletTable());
+  }
+  /**
+   * Creates a converter.
+   *
+   * @param viewExpander    Preparing statement
+   * @param validator       Validator
+   * @param catalogReader   Schema
+   * @param planner         Planner
+   * @param rexBuilder      Rex builder
+   * @param convertletTable Expression converter
+   */
+  public SqlToRelConverter(
+      RelOptTable.ViewExpander viewExpander,
+      SqlValidator validator,
+      Prepare.CatalogReader catalogReader,
+      RelOptPlanner planner,
+      RexBuilder rexBuilder,
+      SqlRexConvertletTable convertletTable) {
     this.viewExpander = viewExpander;
     this.opTab =
         (validator
@@ -159,7 +179,7 @@ public class SqlToRelConverter {
     this.cluster = query.createCluster(typeFactory, rexBuilder);
     this.shouldConvertTableAccess = true;
     this.exprConverter =
-        new SqlNodeToRexConverterImpl(new StandardConvertletTable());
+        new SqlNodeToRexConverterImpl(convertletTable);
     decorrelationEnabled = true;
     trimUnusedFields = false;
     shouldCreateValuesRel = true;

--- a/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
@@ -128,25 +128,6 @@ public class SqlToRelConverter {
   public final RelOptTable.ViewExpander viewExpander;
 
   //~ Constructors -----------------------------------------------------------
-
-  /**
-   * Creates a converter.
-   *
-   * @param viewExpander  Preparing statement
-   * @param validator     Validator
-   * @param catalogReader Schema
-   * @param planner       Planner
-   * @param rexBuilder    Rex builder
-   */
-  public SqlToRelConverter(
-      RelOptTable.ViewExpander viewExpander,
-      SqlValidator validator,
-      Prepare.CatalogReader catalogReader,
-      RelOptPlanner planner,
-      RexBuilder rexBuilder) {
-      this(viewExpander, validator, catalogReader, planner, rexBuilder,
-        new StandardConvertletTable());
-  }
   /**
    * Creates a converter.
    *

--- a/core/src/main/java/org/eigenbase/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/StandardConvertletTable.java
@@ -35,6 +35,11 @@ import com.google.common.collect.ImmutableList;
  * Standard implementation of {@link SqlRexConvertletTable}.
  */
 public class StandardConvertletTable extends ReflectiveConvertletTable {
+
+  // Singleton instance of StandardConvertletTable
+  public static final StandardConvertletTable INSTANCE =
+    new StandardConvertletTable();
+
   //~ Constructors -----------------------------------------------------------
 
   public StandardConvertletTable() {

--- a/core/src/main/java/org/eigenbase/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/StandardConvertletTable.java
@@ -471,6 +471,15 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
     RexNode cast = rexBuilder.makeReinterpretCast(
         resType, exprs.get(1), rexBuilder.makeLiteral(false));
 
+    /* TODO: Handle DateTime types.
+     * Raise exception for now, that we don't extract from DATETIME types
+     */
+    SqlTypeName extractFrom = exprs.get(1).getType().getSqlTypeName();
+    if (SqlTypeFamily.DATETIME.getTypeNames().contains(extractFrom)) {
+      throw new UnsupportedOperationException(
+        "Extract function does not support DATETIME data types");
+    }
+
     SqlIntervalQualifier.TimeUnit unit =
         ((SqlIntervalQualifier) operands.get(0)).getStartUnit();
     long val = unit.multiplier;

--- a/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
@@ -45,6 +45,7 @@ import org.eigenbase.sql.util.ChainedSqlOperatorTable;
 import org.eigenbase.sql.util.ListSqlOperatorTable;
 import org.eigenbase.sql.validate.SqlValidator;
 import org.eigenbase.sql.validate.SqlValidatorScope;
+import org.eigenbase.sql2rel.StandardConvertletTable;
 import org.eigenbase.util.Util;
 
 import com.google.common.collect.ImmutableList;
@@ -130,7 +131,7 @@ public class PlannerTest {
             new ListSqlOperatorTable(
                 ImmutableList.<SqlOperator>of(new MyCountAggFunction()))));
     Planner planner = Frameworks.getPlanner(Lex.ORACLE, SqlParserImpl.FACTORY,
-        HR_FACTORY, opTab, null);
+        HR_FACTORY, opTab, null, StandardConvertletTable.INSTANCE);
     SqlNode parse =
         planner.parse("select \"deptno\", my_count(\"empid\") from \"emps\"\n"
             + "group by \"deptno\"");
@@ -161,7 +162,8 @@ public class PlannerTest {
 
   private Planner getPlanner(List<RelTraitDef> traitDefs, RuleSet... ruleSets) {
     return Frameworks.getPlanner(Lex.ORACLE, SqlParserImpl.FACTORY,
-        HR_FACTORY, SqlStdOperatorTable.instance(), traitDefs, ruleSets);
+        HR_FACTORY, SqlStdOperatorTable.instance(), traitDefs,
+        StandardConvertletTable.INSTANCE, ruleSets);
   }
 
   /** Tests that planner throws an error if you pass to

--- a/core/src/test/java/org/eigenbase/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/eigenbase/sql/test/SqlOperatorBaseTest.java
@@ -34,6 +34,7 @@ import org.eigenbase.test.*;
 import org.eigenbase.util.*;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -4040,6 +4041,28 @@ public abstract class SqlOperatorBaseTest {
         "BIGINT NOT NULL");
     tester.checkNull(
         "extract(month from cast(null as interval year))");
+  }
+
+  @Ignore public void testExtractFuncFromDateTime() {
+    /* StandardConvertletTable.convertExtract() will throw an
+     * exception when the second input to extract function is of
+     * DATETIME type. Once the capability to handle DATETIME type
+     * is added to convertExtract() we can add this test
+     */
+    tester.setFor(
+        SqlStdOperatorTable.EXTRACT,
+        VM_FENNEL,
+        VM_JAVA);
+
+    tester.checkScalar(
+        "extract(year from date '2008-2-23')",
+        "2008",
+        "BIGINT NOT NULL");
+
+    tester.checkScalar(
+        "extract(minute from time '12:23:34')",
+        "23",
+        "BIGINT NOT NULL");
   }
 
   @Test public void testArrayValueConstructor() {

--- a/core/src/test/java/org/eigenbase/test/SqlToRelTestBase.java
+++ b/core/src/test/java/org/eigenbase/test/SqlToRelTestBase.java
@@ -435,7 +435,8 @@ public abstract class SqlToRelTestBase {
               validator,
               catalogReader,
               getPlanner(),
-              new RexBuilder(typeFactory));
+              new RexBuilder(typeFactory),
+              StandardConvertletTable.INSTANCE);
     }
 
     protected final RelDataTypeFactory getTypeFactory() {

--- a/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/eigenbase/test/SqlValidatorTest.java
@@ -5769,6 +5769,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         "extract(year from interval '1-2' year to month)",
         "BIGINT NOT NULL");
     checkExp("extract(minute from interval '1.1' second)");
+    checkExp("extract(year from DATE '2008-2-2')");
 
     checkWholeExpFails(
         "extract(minute from interval '11' month)",


### PR DESCRIPTION
Currently extract() function only supports extracting time units from an Interval data type. This patch extends the extract() function to support DateTime.

In StandardConvertletTable() we reinterpret the extract() function to be a '/' expression based on the input data types. The problem is for Drill we cannot rewrite the extract() function this early because the data types are still 'ANY' and we cannot determine the multiplier to be used in the '/' expression while rewriting it.

Drill will extend the StandardConvertletTable() and override the convertExtract() method to simply treat it like a regular function and not rewrite it. 
