### PR TITLE
Use separate variables for "expr != null" conditions. This allows to reu...

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/rules/java/JavaRules.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/JavaRules.java
@@ -2041,20 +2041,22 @@ public class JavaRules {
                       source_,
                       BuiltinMethod.INTO.method,
                       Expressions.new_(ArrayList.class)),
-                  List.class));
+                  List.class),
+              false); // forbid sharing of temp list
           iterator_ = builder.append(
               "iterator",
               Expressions.call(
                   null,
                   BuiltinMethod.SORTED_MULTI_MAP_SINGLETON.method,
                   comparator_,
-                  tempList_));
-
+                  tempList_),
+              false); // forbid sharing of tempList.iterator()
           collectionExpr = tempList_;
         } else {
           Expression multiMap_ =
               builder.append(
-                  "multiMap", Expressions.new_(SortedMultiMap.class));
+                  "multiMap", Expressions.new_(SortedMultiMap.class),
+                  false); // forbid to reuse multimap
           final BlockBuilder builder2 = new BlockBuilder();
           final ParameterExpression v_ =
               Expressions.parameter(inputPhysType.getJavaRowType(),
@@ -2092,7 +2094,8 @@ public class JavaRules {
               Expressions.call(
                   multiMap_,
                   BuiltinMethod.SORTED_MULTI_MAP_ARRAYS.method,
-                  comparator_));
+                  comparator_),
+              false); // forbid to reuse sortedMap.iterator()
 
           collectionExpr = multiMap_;
         }

--- a/core/src/main/java/net/hydromatic/optiq/rules/java/RexToLixTranslator.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/RexToLixTranslator.java
@@ -128,6 +128,25 @@ public class RexToLixTranslator {
   Expression translate(RexNode expr, RexImpTable.NullAs nullAs) {
     Expression expression = translate0(expr, nullAs);
     assert expression != null;
+    if (expression instanceof BinaryExpression && (
+        nullAs == RexImpTable.NullAs.IS_NULL
+        || nullAs == RexImpTable.NullAs.IS_NOT_NULL)) {
+      // When translating resulted in expr != null expression,
+      // add expr as standalone one.
+      // This eliminates multiple calls to expr
+      // v1 = expr!=null ->  v0 = expr; v1 = v0!=null
+      BinaryExpression binaryExpression = (BinaryExpression) expression;
+      Expression expr0 = binaryExpression.expression0;
+      if (binaryExpression.expression1 == RexImpTable.NULL_EXPR
+          && !(expr0 instanceof ConstantExpression
+               || expr0 instanceof DefaultExpression)
+          && (binaryExpression.getNodeType() == ExpressionType.Equal
+          || binaryExpression.getNodeType() == ExpressionType.NotEqual)) {
+        Expression v0 = list.append("t", binaryExpression.expression0);
+        expression = Expressions.makeBinary(binaryExpression.getNodeType(),
+            v0, RexImpTable.NULL_EXPR);
+      }
+    }
     return list.append("v", expression);
   }
 

--- a/core/src/test/java/net/hydromatic/optiq/test/ReflectiveSchemaTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/ReflectiveSchemaTest.java
@@ -350,7 +350,9 @@ public class ReflectiveSchemaTest {
         "select \"wrapperLong\" / \"primitiveLong\" as c\n"
         + " from \"s\".\"everyTypes\" where \"primitiveLong\" <> 0")
         .planContains(
-            "return current13.wrapperLong == null ? (Long) null : Long.valueOf(current13.wrapperLong.longValue() / current13.primitiveLong);")
+            "final Long v = current13.wrapperLong;")
+        .planContains(
+            "return v == null ? (Long) null : Long.valueOf(v.longValue() / current13.primitiveLong);")
         .returns("C=null\n");
     with.query(
         "select \"wrapperLong\" / \"wrapperLong\" as c\n"

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>net.hydromatic</groupId>
       <artifactId>linq4j</artifactId>
-      <version>0.1.13</version>
+      <version>0.1.14-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
...se the result of expr calculation

This is a basic reuse of expressions that might duplicate out of "null-checks".
For instance: `upper(udf(1))` is typically translated to `udf(1) == null ? null : upper(udf(1))`
The fix parttern-matches `XXX == null` and factors `XXX` to separate declaration.
Thus final expression becomes `v0 = udf(1); v1 = v0 == null ? null : upper(v0)`

The fix requires equals/hashCode support from linq4j: https://github.com/julianhyde/linq4j/pull/12
