### PR TITLE
Fix translation of user-defined functions

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/rules/java/RexImpTable.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/RexImpTable.java
@@ -610,7 +610,9 @@ public class RexImpTable {
         }
       }
     }
-    return implementor.implement(translator, call, translatedOperands);
+    Expression result;
+    result = implementor.implement(translator, call, translatedOperands);
+    return nullAs.handle(result);
   }
 
   /** Implements an aggregate function by generating a call to a method that

--- a/core/src/main/java/org/eigenbase/sql/SqlUnresolvedFunction.java
+++ b/core/src/main/java/org/eigenbase/sql/SqlUnresolvedFunction.java
@@ -1,0 +1,57 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.sql;
+
+import java.util.List;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.sql.type.SqlOperandTypeChecker;
+import org.eigenbase.sql.type.SqlOperandTypeInference;
+import org.eigenbase.sql.type.SqlReturnTypeInference;
+
+/**
+ * Placeholder for user-defined function.
+ * <p/>
+ * <p>Created by the parser, then it is rewritten to proper SqlFunction by
+ * the validator to a function defined in an Optiq schema.</p>
+ */
+public class SqlUnresolvedFunction extends SqlFunction {
+
+  /**
+   * Creates a placeholder SqlUnresolvedFunction for an invocation of a function
+   * with a possibly qualified name. This name must be resolved into either
+   * a builtin function or a user-defined function.
+   *
+   * @param sqlIdentifier        possibly qualified identifier for function
+   * @param returnTypeInference  strategy to use for return type inference
+   * @param operandTypeInference strategy to use for parameter type inference
+   * @param operandTypeChecker   strategy to use for parameter type checking
+   * @param paramTypes           array of parameter types
+   * @param funcType             function category
+   */
+  public SqlUnresolvedFunction(
+      SqlIdentifier sqlIdentifier,
+      SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeInference operandTypeInference,
+      SqlOperandTypeChecker operandTypeChecker,
+      List<RelDataType> paramTypes,
+      SqlFunctionCategory funcType) {
+    super(sqlIdentifier, returnTypeInference, operandTypeInference,
+        operandTypeChecker, paramTypes, funcType);
+  }
+}

--- a/core/src/main/java/org/eigenbase/sql/parser/SqlAbstractParserImpl.java
+++ b/core/src/main/java/org/eigenbase/sql/parser/SqlAbstractParserImpl.java
@@ -359,7 +359,8 @@ public abstract class SqlAbstractParserImpl {
     // Otherwise, just create a placeholder function.  Later, during
     // validation, it will be resolved into a real function reference.
     if (fun == null) {
-      fun = new SqlFunction(funName, null, null, null, null, funcType);
+      fun = new SqlUnresolvedFunction(funName, null, null, null, null,
+          funcType);
     }
 
     return fun.createCall(functionQualifier, pos, operands);

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedFunction.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedFunction.java
@@ -23,14 +23,11 @@ import java.util.List;
 import org.eigenbase.reltype.RelDataType;
 import org.eigenbase.reltype.RelDataTypeFactory;
 import org.eigenbase.reltype.RelDataTypeFactoryImpl;
-import org.eigenbase.sql.SqlFunction;
-import org.eigenbase.sql.SqlKind;
-import org.eigenbase.sql.SqlLiteral;
-import org.eigenbase.sql.SqlNode;
-import org.eigenbase.sql.SqlUtil;
+import org.eigenbase.sql.*;
 import org.eigenbase.sql.type.*;
 import org.eigenbase.util.NlsString;
 import org.eigenbase.util.Pair;
+import org.eigenbase.util.Util;
 
 import net.hydromatic.optiq.*;
 
@@ -43,10 +40,10 @@ import net.hydromatic.optiq.*;
 public class SqlUserDefinedFunction extends SqlFunction {
   public final Function function;
 
-  public SqlUserDefinedFunction(String name, RelDataType returnType,
+  public SqlUserDefinedFunction(SqlIdentifier opName, RelDataType returnType,
       List<RelDataType> argTypes, List<SqlTypeFamily> typeFamilies,
       Function function) {
-    super(name, null, SqlKind.OTHER_FUNCTION,
+    super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
         ReturnTypes.explicit(returnType),
         new ExplicitOperandTypeInference(argTypes),
         OperandTypes.family(typeFamilies),

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorImpl.java
@@ -881,20 +881,20 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         }
       }
 
-      if (call.getOperator() instanceof SqlFunction) {
-        SqlFunction function = (SqlFunction) call.getOperator();
-        if (function.getFunctionType() == null) {
-          // This function hasn't been resolved yet.  Perform
-          // a half-hearted resolution now in case it's a
-          // builtin function requiring special casing.  If it's
-          // not, we'll handle it later during overload
-          // resolution.
-          final List<SqlOperator> overloads = Lists.newArrayList();
-          opTab.lookupOperatorOverloads(function.getNameAsId(), null,
-              SqlSyntax.FUNCTION, overloads);
-          if (overloads.size() == 1) {
-            ((SqlBasicCall) call).setOperator(overloads.get(0));
-          }
+      if (call.getOperator() instanceof SqlUnresolvedFunction) {
+        SqlUnresolvedFunction function = (SqlUnresolvedFunction) call
+            .getOperator();
+        // This function hasn't been resolved yet.  Perform
+        // a half-hearted resolution now in case it's a
+        // builtin function requiring special casing.  If it's
+        // not, we'll handle it later during overload
+        // resolution.
+        final List<SqlOperator> overloads = Lists.newArrayList();
+        opTab.lookupOperatorOverloads(function.getNameAsId(),
+            function.getFunctionType(),
+            SqlSyntax.FUNCTION, overloads);
+        if (overloads.size() == 1) {
+          ((SqlBasicCall) call).setOperator(overloads.get(0));
         }
       }
       if (rewriteCalls) {

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -2834,6 +2834,24 @@ public class JdbcTest {
             "");
   }
 
+  /**
+   * Tests derived return type of user-defined function.
+   */
+  @Test
+  public void testUDFDerivedReturnType() {
+    final OptiqAssert.AssertThat with = prepareUDFSchema();
+    with.query(
+        "select max(\"adhoc\".my_double(\"deptno\")) as p from \"adhoc\"."
+        + "EMPLOYEES")
+        .returns(
+            "P=40\n");
+    with.query(
+        "select max(\"adhoc\".my_str(\"name\")) as p from \"adhoc\"."
+        + "EMPLOYEES where \"adhoc\".my_str(\"name\") is null")
+        .returns(
+            "P=null\n");
+  }
+
   /** Tests user-defined function. */
   @Test public void testUserDefinedFunction2() throws Exception {
     OptiqAssert.that()


### PR DESCRIPTION
This fixes https://github.com/julianhyde/optiq/issues/228 and a new issue -- `max(udf(...))`

When deriving type of `SqlUserDefinedFunction` we might want to skip verification (i.e. override `deriveType`) since `SqlUserDefinedFunction` is already resolved.
I did not create such an override since very few classes have one and I am not sure if it is proper in particular case.
