### PR TITLE
Add files to .gitignore that shouldn't be checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@ target
 settings.xml
 .classpath.txt
 .fullclasspath.txt
-
+.project
+.buildpath
+.classpath
+.settings
+*Test.log.xml


### PR DESCRIPTION
Adding this so that I don't continue to forget to add new files that are hidden within all the extraneous do not add files.  Excludes both Eclipse project files as well as output from some tests that go into the src tree.
