### PR TITLE
RelOptTableImpl.create always expects QueryableTable type in OptiqSchema...

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/prepare/RelOptTableImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/RelOptTableImpl.java
@@ -84,16 +84,24 @@ public class RelOptTableImpl implements Prepare.PreparingTable {
       RelOptSchema schema,
       RelDataType rowType,
       final OptiqSchema.TableEntry tableEntry) {
-    final QueryableTable table = (QueryableTable) tableEntry.getTable();
-    final Function<Class, Expression> expressionFunction =
-        new Function<Class, Expression>() {
-          public Expression apply(Class clazz) {
-            return table.getExpression(tableEntry.schema.plus(),
-                tableEntry.name, clazz);
-          }
-        };
-    return new RelOptTableImpl(schema, rowType, tableEntry.path(), table,
-        expressionFunction);
+    Function<Class, Expression> expressionFunction;
+    if (tableEntry.getTable() instanceof QueryableTable) {
+      final QueryableTable table = (QueryableTable) tableEntry.getTable();
+      expressionFunction = new Function<Class, Expression>() {
+        public Expression apply(Class clazz) {
+          return table.getExpression(tableEntry.schema.plus(),
+              tableEntry.name, clazz);
+        }
+      };
+    } else {
+      expressionFunction = new Function<Class, Expression>() {
+        public Expression apply(Class input) {
+          throw new UnsupportedOperationException();
+        }
+      };
+    }
+    return new RelOptTableImpl(schema, rowType, tableEntry.path(),
+      tableEntry.getTable(), expressionFunction);
   }
 
   public static RelOptTableImpl create(


### PR DESCRIPTION
....TableEntry.

Trying Drill with optiq 0.6-SNAPSHOT and I ran into the class cast problem in `RelOptTableImpl.create(RelOptSchema schema, RelDataType rowType, final TableEntry tableEntry)` 

This breaks when the tables are subtypes of Table and not Queryable table. In Drill case all tables implement Table interface and not QueryableTable. This seems to be a regression from issue https://github.com/julianhyde/optiq/issues/222.
