### PR TITLE
Fetch and Limit RexNodes are ignored when creating a new SqlRel object f...

### DIFF
--- a/core/src/main/java/org/eigenbase/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/RelDecorrelator.java
@@ -310,7 +310,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
             rel.getCluster(),
             rel.getCluster().traitSetOf(Convention.NONE).plus(newCollation),
             newChildRel,
-            newCollation);
+            newCollation,
+            rel.offset,
+            rel.fetch);
 
     mapOldToNewRel.put(rel, newRel);
 

--- a/core/src/main/java/org/eigenbase/sql2rel/RelStructuredTypeFlattener.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/RelStructuredTypeFlattener.java
@@ -348,7 +348,9 @@ public class RelStructuredTypeFlattener implements ReflectiveVisitor {
             rel.getCluster(),
             rel.getCluster().traitSetOf(Convention.NONE).plus(newCollation),
             newChild,
-            newCollation);
+            newCollation,
+            rel.offset,
+            rel.fetch);
     setNewForOldRel(rel, newRel);
   }
 

--- a/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
@@ -59,22 +59,79 @@ import static org.junit.Assert.*;
  * Unit tests for {@link Planner}.
  */
 public class PlannerTest {
-  @Test public void testParseAndConvert() throws Exception {
+  private void testParseAndConvertHelper(String query,
+    String queryFromParseTree, String expectedRelExpr) throws Exception {
     Planner planner = getPlanner(null);
-    SqlNode parse =
-        planner.parse("select * from \"emps\" where \"name\" like '%e%'");
-    assertThat(Util.toLinux(parse.toString()), equalTo(
-        "SELECT *\n"
-        + "FROM `emps`\n"
-        + "WHERE `name` LIKE '%e%'"));
+    SqlNode parse = planner.parse(query);
+    assertThat(Util.toLinux(parse.toString()), equalTo(queryFromParseTree));
 
     SqlNode validate = planner.validate(parse);
     RelNode rel = planner.convert(validate);
-    assertThat(toString(rel),
-        equalTo(
-            "ProjectRel(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
-            + "  FilterRel(condition=[LIKE($2, '%e%')])\n"
-            + "    EnumerableTableAccessRel(table=[[hr, emps]])\n"));
+    assertThat(toString(rel), equalTo(expectedRelExpr));
+  }
+
+  @Test public void testParseAndConvert() throws Exception {
+    testParseAndConvertHelper(
+        "select * from \"emps\" where \"name\" like '%e%'",
+
+        "SELECT *\n"
+        + "FROM `emps`\n"
+        + "WHERE `name` LIKE '%e%'",
+
+        "ProjectRel(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
+        + "  FilterRel(condition=[LIKE($2, '%e%')])\n"
+        + "    EnumerableTableAccessRel(table=[[hr, emps]])\n");
+  }
+
+  /** Unit test that parses, validates and converts the query
+   * using order by and limit */
+  @Test public void testParseAndConvertWithOrderByAndLimit()
+    throws Exception {
+    testParseAndConvertHelper(
+      "select * from \"emps\" "
+      + "order by \"emps\".\"deptno\" limit 1",
+
+      "SELECT *\n"
+      + "FROM `emps`\n"
+      + "ORDER BY `emps`.`deptno`\n"
+      + "FETCH NEXT 1 ROWS ONLY",
+
+      "SortRel(sort0=[$1], dir0=[ASC], fetch=[1])\n"
+      + "  ProjectRel(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
+      + "    EnumerableTableAccessRel(table=[[hr, emps]])\n");
+  }
+
+  /** Unit test that parses, validates and converts the query using
+   * order by and offset */
+  @Test public void testParseAndConvertWithOrderByAndOffset()
+    throws Exception {
+    testParseAndConvertHelper(
+      "select * from \"emps\" "
+      + "order by \"emps\".\"deptno\" offset 10",
+
+      "SELECT *\n"
+      + "FROM `emps`\n"
+      + "ORDER BY `emps`.`deptno`\n"
+      + "OFFSET 10 ROWS",
+
+      "SortRel(sort0=[$1], dir0=[ASC], offset=[10])\n"
+      + "  ProjectRel(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
+      + "    EnumerableTableAccessRel(table=[[hr, emps]])\n");
+  }
+
+  /** Unit test that parses, validates and converts the query using limit */
+  @Test public void testParseAndConvertWithLimit()
+    throws Exception {
+    testParseAndConvertHelper(
+      "select * from \"emps\" limit 10",
+
+      "SELECT *\n"
+      + "FROM `emps`\n"
+      + "FETCH NEXT 10 ROWS ONLY",
+
+      "SortRel(fetch=[10])\n"
+      + "  ProjectRel(empid=[$0], deptno=[$1], name=[$2], salary=[$3], commission=[$4])\n"
+      + "    EnumerableTableAccessRel(table=[[hr, emps]])\n");
   }
 
   private String toString(RelNode rel) {


### PR DESCRIPTION
...rom existing SqlRel.

With recent optiq 0.6-SNAPSHOT there were few test cases related to LIMIT are failing in Drill. @jinfengni and I debugged the issue. It turns out that when creating a new SqlRel object from an existing SqlRel object, we ignore passing fetch and offset RexNodes from source to new SqlRel object. We were hitting this issue in `RelStructuredTypeFlattener. rewriteRel`. This code path of flattening is newly added in change https://github.com/julianhyde/optiq/commit/3f127ce51ff424409e0e54afa62ac34d49734ebb. 

We also noticed there is one another place `RelDecorrelator` where we ignore the offset and fetch.  Not sure which query hits this code path, so didn't add any test cases to test this code path.
