### PR TITLE
Add FrameworkContext and FrameworkConfig

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/impl/ViewTable.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/ViewTable.java
@@ -138,6 +138,16 @@ public class ViewTable
       return apply(Collections.emptyList()).getRowType(typeFactory);
     }
   }
+
+  /** Get the view's SQL definition. */
+  public String getViewSql() {
+    return viewSql;
+  }
+
+  /** Get the schemapath of the view */
+  public List<String> getSchemaPath() {
+    return schemaPath;
+  }
 }
 
 // End ViewTable.java

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
@@ -34,6 +34,7 @@ import net.hydromatic.optiq.materialize.MaterializationService;
 import net.hydromatic.optiq.rules.java.*;
 import net.hydromatic.optiq.runtime.*;
 import net.hydromatic.optiq.server.OptiqServerStatement;
+import net.hydromatic.optiq.tools.FrameworkContext;
 import net.hydromatic.optiq.tools.Frameworks;
 
 import org.eigenbase.rel.*;
@@ -138,15 +139,18 @@ public class OptiqPrepareImpl implements OptiqPrepare {
     return Collections.<Function1<Context, RelOptPlanner>>singletonList(
         new Function1<Context, RelOptPlanner>() {
           public RelOptPlanner apply(Context context) {
-            return createPlanner(context);
+            return createPlanner(context, null, null);
           }
         });
   }
 
   /** Creates a query planner and initializes it with a default set of
    * rules. */
-  protected RelOptPlanner createPlanner(Context context) {
-    final VolcanoPlanner planner = new VolcanoPlanner();
+  protected RelOptPlanner createPlanner(Context context, //
+      FrameworkContext frameworkContext, //
+      RelOptCostFactory costFactory) {
+    final VolcanoPlanner planner = //
+        new VolcanoPlanner(costFactory, frameworkContext);
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
     if (ENABLE_COLLATION_TRAIT) {
       planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
@@ -511,7 +515,9 @@ public class OptiqPrepareImpl implements OptiqPrepare {
         context.getDefaultSchemaPath(),
         typeFactory);
     final RexBuilder rexBuilder = new RexBuilder(typeFactory);
-    final RelOptPlanner planner = createPlanner(context);
+    final RelOptPlanner planner = createPlanner(context, //
+        action.getConfig().getFrameworkContext(), //
+        action.getConfig().getCostFactory());
     final RelOptQuery query = new RelOptQuery(planner);
     final RelOptCluster cluster =
         query.createCluster(rexBuilder.getTypeFactory(), rexBuilder);

--- a/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
@@ -25,17 +25,22 @@ import net.hydromatic.optiq.tools.*;
 
 import org.eigenbase.rel.RelNode;
 import org.eigenbase.relopt.*;
+import org.eigenbase.relopt.RelOptTable.ViewExpander;
+import org.eigenbase.reltype.RelDataType;
 import org.eigenbase.rex.RexBuilder;
 import org.eigenbase.sql.SqlNode;
 import org.eigenbase.sql.SqlOperatorTable;
 import org.eigenbase.sql.parser.SqlParseException;
 import org.eigenbase.sql.parser.SqlParser;
 import org.eigenbase.sql.parser.SqlParserImplFactory;
+import org.eigenbase.sql.validate.SqlValidator;
 import org.eigenbase.sql2rel.SqlRexConvertletTable;
 import org.eigenbase.sql2rel.SqlToRelConverter;
 import org.eigenbase.util.Util;
 
 import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 /** Implementation of {@link net.hydromatic.optiq.tools.Planner}. */
 public class PlannerImpl implements Planner {
@@ -180,7 +185,7 @@ public class PlannerImpl implements Planner {
     assert validatedSqlNode != null;
     this.sqlToRelConverter =
         new SqlToRelConverter(
-            null, validator, createCatalogReader(), planner,
+            new ViewExpanderImpl(), validator, createCatalogReader(), planner,
             createRexBuilder(), convertletTable);
     sqlToRelConverter.setTrimUnusedFields(false);
     sqlToRelConverter.enableTableAccessConversion(false);
@@ -189,6 +194,38 @@ public class PlannerImpl implements Planner {
     rel = sqlToRelConverter.decorrelate(validatedSqlNode, rel);
     state = State.STATE_5_CONVERTED;
     return rel;
+  }
+
+  /** Implements {@link org.eigenbase.relopt.RelOptTable.ViewExpander}
+   * interface for {@link net.hydromatic.optiq.tools.Planner} */
+  public class ViewExpanderImpl implements ViewExpander {
+    public RelNode expandView(RelDataType rowType, String queryString,
+        List<String> schemaPath) {
+      SqlParser parser = SqlParser.create(parserFactory, queryString,
+          lex.quoting, lex.unquotedCasing, lex.quotedCasing);
+      SqlNode sqlNode;
+      try {
+        sqlNode = parser.parseQuery();
+      } catch (SqlParseException e) {
+        throw new RuntimeException("parse failed", e);
+      }
+
+      final OptiqCatalogReader catalogReader =
+          createCatalogReader().withSchemaPath(schemaPath);
+      SqlValidator validator = new OptiqSqlValidator(
+          operatorTable, catalogReader, typeFactory);
+      SqlNode validatedSqlNode = validator.validate(sqlNode);
+
+      SqlToRelConverter sqlToRelConverter = new SqlToRelConverter(
+          null, validator, catalogReader, planner,
+          createRexBuilder(), convertletTable);
+      sqlToRelConverter.setTrimUnusedFields(false);
+
+      RelNode relNode = sqlToRelConverter.convertQuery(
+          validatedSqlNode, true, false);
+
+      return relNode;
+    }
   }
 
   // OptiqCatalogReader is stateless; no need to store one

--- a/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/PlannerImpl.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableList;
 public class PlannerImpl implements Planner {
   private final SqlOperatorTable operatorTable;
   private final ImmutableList<RuleSet> ruleSets;
+  private final FrameworkConfig config;
 
   /** Holds the trait definitions to be registered with planner. May be null. */
   private final ImmutableList<RelTraitDef> traitDefs;
@@ -70,22 +71,20 @@ public class PlannerImpl implements Planner {
   private SqlRexConvertletTable convertletTable;
   private RelNode rel;
 
+
+
   /** Creates a planner. Not a public API; call
    * {@link net.hydromatic.optiq.tools.Frameworks#getPlanner} instead. */
-  public PlannerImpl(Lex lex, SqlParserImplFactory parserFactory,
-      SchemaPlus defaultSchema,
-      SqlOperatorTable operatorTable, ImmutableList<RuleSet> ruleSets,
-      ImmutableList<RelTraitDef> traitDefs,
-      SqlRexConvertletTable convertletTable) {
-    assert defaultSchema != null;
-    this.defaultSchema = defaultSchema;
-    this.operatorTable = operatorTable;
-    this.ruleSets = ruleSets;
-    this.lex = lex;
-    this.parserFactory = parserFactory;
+  public PlannerImpl(FrameworkConfig config) {
+    this.config = config;
+    this.defaultSchema = config.getDefaultSchema();
+    this.operatorTable = config.getOperatorTable();
+    this.ruleSets = config.getRuleSets();
+    this.lex = config.getLex();
+    this.parserFactory = config.getParserFactory();
     this.state = State.STATE_0_CLOSED;
-    this.traitDefs = traitDefs;
-    this.convertletTable = convertletTable;
+    this.traitDefs = config.getTraitDefs();
+    this.convertletTable = config.getConvertletTable();
     reset();
   }
 
@@ -132,7 +131,8 @@ public class PlannerImpl implements Planner {
             planner = cluster.getPlanner();
             return null;
           }
-        });
+        },
+        config);
 
     state = State.STATE_2_READY;
 

--- a/core/src/main/java/net/hydromatic/optiq/prepare/Prepare.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/Prepare.java
@@ -146,7 +146,7 @@ public abstract class Prepare {
         .addRuleInstance(MergeProjectOntoCalcRule.INSTANCE)
         .build();
     final HepPlanner planner3 =
-        new HepPlanner(program, true,
+        new HepPlanner(program, null, true,
             Functions.<RelNode, RelNode, Void>ignore2(),
             RelOptCostImpl.FACTORY);
     List<RelMetadataProvider> list = Lists.newArrayList();

--- a/core/src/main/java/net/hydromatic/optiq/tools/FrameworkConfig.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/FrameworkConfig.java
@@ -1,0 +1,121 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.tools;
+
+import net.hydromatic.optiq.SchemaPlus;
+import net.hydromatic.optiq.config.Lex;
+
+import org.eigenbase.relopt.RelOptCostFactory;
+import org.eigenbase.relopt.RelTraitDef;
+import org.eigenbase.sql.SqlOperatorTable;
+import org.eigenbase.sql.parser.SqlParserImplFactory;
+import org.eigenbase.sql2rel.SqlRexConvertletTable;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Interface that describes how to configure planning sessions generated
+ * using the Frameworks tools.
+ */
+public interface FrameworkConfig {
+
+  /**
+   * The type of lexing the SqlParser should do.  Controls case rules
+   * and quoted identifier syntax.
+   */
+  Lex getLex();
+
+
+  /**
+   * Provides the Parser factory that creates the SqlParser used in parsing
+   * queries.
+   */
+  SqlParserImplFactory getParserFactory();
+
+  /**
+   * Returns the default schema that should be checked before looking at the
+   * root schema.  Return null to only consult the root schema.
+   */
+  SchemaPlus getDefaultSchema();
+
+
+  /**
+   * Returns an array of one or more rule sets used during the course of
+   * query evaluation. The common use case is when there is a single rule
+   * set and {@link net.hydromatic.optiq.tools.Planner#transform}
+   * will only be called once. However, consumers may also register multiple
+   * {@link net.hydromatic.optiq.tools.RuleSet}s and do multiple repetitions
+   * of {@link Planner#transform} planning cycles using different indices.
+   * The order of rule sets provided here determines the zero-based indices
+   * of rule sets elsewhere in this class.
+   */
+  ImmutableList<RuleSet> getRuleSets();
+
+
+  /**
+   * Return the instance of SqlOperatorTable that should be used to
+   * resolve Optiq operators.
+   */
+  SqlOperatorTable getOperatorTable();
+
+
+
+  /**
+   * Return the cost factory that should be used when creating the planner.
+   * If null, use the default cost factory for that planner.
+   */
+  RelOptCostFactory getCostFactory();
+
+
+/**
+   * <p>If {@code traitDefs} is non-null, the planner first de-registers any
+   * existing {@link RelTraitDef}s, then registers the {@code RelTraitDef}s in
+   * this list.</p>
+   *
+   * <p>The order of {@code RelTraitDef}s in {@code traitDefs} matters if the
+   * planner is VolcanoPlanner. The planner calls {@link RelTraitDef#convert} in
+   * the order of this list. The most important trait comes first in the list,
+   * followed by the second most important one, etc.</p>
+   *
+   * @param lex The type of lexing the SqlParser should do.  Controls case rules
+   *     and quoted identifier syntax.
+   * @param parserFactory
+   * @param operatorTable The instance of SqlOperatorTable that be should to
+   *     resolve Optiq operators.
+   * @param ruleSets
+   *  @param  traitDefs The list of RelTraitDef that would be registered with
+   *     planner, or null.
+ * @return
+ */
+  ImmutableList<RelTraitDef> getTraitDefs();
+
+
+
+
+  /**
+   * Return the convertlet table that should be used when converting from Sql
+   * to row expressions
+   */
+  SqlRexConvertletTable getConvertletTable();
+
+  /**
+   * Returns the PlannerContext that should be made available during planning by
+   * calling {@link org.eigenbase.relopt.RelOptPlanner#getPlannerContext}
+   */
+  FrameworkContext getFrameworkContext();
+}

--- a/core/src/main/java/net/hydromatic/optiq/tools/FrameworkContext.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/FrameworkContext.java
@@ -1,0 +1,34 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.tools;
+
+/**
+ * Provides frameworks a way to store data within the planner session and
+ * access it within rules. Frameworks can implement their own implementation
+ * of FrameworkContext and pass that as part of the FrameworkConfig.
+ */
+public interface FrameworkContext {
+
+  /**
+   * If assignable to clazz, provide the underlying clazz.
+   * @param clazz The Class object of the desired class.
+   * @return Underlying object if matches, otherwise null.
+   */
+  <T> T unwrap(Class<T> clazz);
+
+}

--- a/core/src/main/java/net/hydromatic/optiq/tools/StdFrameworkConfig.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/StdFrameworkConfig.java
@@ -1,0 +1,205 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.tools;
+
+
+import net.hydromatic.optiq.SchemaPlus;
+import net.hydromatic.optiq.config.Lex;
+
+import org.eigenbase.relopt.RelOptCostFactory;
+import org.eigenbase.relopt.RelTraitDef;
+import org.eigenbase.sql.SqlOperatorTable;
+import org.eigenbase.sql.fun.SqlStdOperatorTable;
+import org.eigenbase.sql.parser.SqlParserImplFactory;
+import org.eigenbase.sql.parser.impl.SqlParserImpl;
+import org.eigenbase.sql2rel.SqlRexConvertletTable;
+import org.eigenbase.sql2rel.StandardConvertletTable;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * An implementation of {@link FrameworkConfig} that uses standard Optiq
+ * classes to provide basic planner functionality.
+ */
+public class StdFrameworkConfig implements FrameworkConfig {
+
+  private final FrameworkContext context;
+  private final SqlRexConvertletTable convertletTable;
+  private final SqlOperatorTable operatorTable;
+  private final ImmutableList<RuleSet> ruleSets;
+  private final ImmutableList<RelTraitDef> traitDefs;
+  private final Lex lex;
+  private final SchemaPlus defaultSchema;
+  private final RelOptCostFactory costFactory;
+  private final SqlParserImplFactory parserFactory;
+
+
+  public StdFrameworkConfig(FrameworkContext context, //
+      SqlRexConvertletTable convertletTable, //
+      SqlOperatorTable operatorTable, //
+      ImmutableList<RuleSet> ruleSets, //
+      ImmutableList<RelTraitDef> traitDefs,
+      Lex lex, //
+      SchemaPlus defaultSchema, //
+      RelOptCostFactory costFactory, //
+      SqlParserImplFactory parserFactory) {
+    super();
+    this.context = context;
+    this.convertletTable = convertletTable;
+    this.operatorTable = operatorTable;
+    this.ruleSets = ruleSets;
+    this.traitDefs = traitDefs;
+    this.lex = lex;
+    this.defaultSchema = defaultSchema;
+    this.costFactory = costFactory;
+    this.parserFactory = parserFactory;
+  }
+
+  public Lex getLex() {
+    return lex;
+  }
+
+  public SqlParserImplFactory getParserFactory() {
+    return parserFactory;
+  }
+
+  public SchemaPlus getDefaultSchema() {
+    return defaultSchema;
+  }
+
+  public ImmutableList<RuleSet> getRuleSets() {
+    return ruleSets;
+  }
+
+  public RelOptCostFactory getCostFactory() {
+    return costFactory;
+  }
+
+  public ImmutableList<RelTraitDef> getTraitDefs() {
+    return traitDefs;
+  }
+
+  public SqlRexConvertletTable getConvertletTable() {
+    return convertletTable;
+  }
+
+  public FrameworkContext getFrameworkContext() {
+    return context;
+  }
+
+  public SqlOperatorTable getOperatorTable() {
+    return operatorTable;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * A builder class to help you build a StdFrameworkConfig using defaults
+   * where values aren't required.
+   */
+  public static class Builder {
+    private SqlRexConvertletTable convertletTable =
+        StandardConvertletTable.INSTANCE;
+    private SqlOperatorTable operatorTable = SqlStdOperatorTable.instance();
+    private ImmutableList<RuleSet> ruleSets = ImmutableList.of();
+    private FrameworkContext context;
+    private ImmutableList<RelTraitDef> traitDefs;
+    private Lex lex = Lex.ORACLE;
+    private SchemaPlus defaultSchema;
+    private RelOptCostFactory costFactory;
+    private SqlParserImplFactory parserFactory = SqlParserImpl.FACTORY;
+
+    private Builder() {}
+
+    public StdFrameworkConfig build() {
+      return new StdFrameworkConfig(context, convertletTable, operatorTable,
+          ruleSets, traitDefs, lex, defaultSchema, costFactory, //
+          parserFactory);
+    }
+
+    public Builder context(FrameworkContext c) {
+      Preconditions.checkNotNull(c);
+      this.context = c;
+      return this;
+    };
+
+    public Builder convertletTable(SqlRexConvertletTable table) {
+      Preconditions.checkNotNull(table);
+      this.convertletTable = table;
+      return this;
+    }
+
+    public Builder operatorTable(SqlOperatorTable table) {
+      Preconditions.checkNotNull(table);
+      this.operatorTable = table;
+      return this;
+    }
+
+    public Builder traitDefs(List<RelTraitDef> traitDefs) {
+      if (traitDefs == null) {
+        this.traitDefs = null;
+      } else {
+        this.traitDefs = ImmutableList.copyOf(traitDefs);
+      }
+      return this;
+    }
+
+    public Builder traitDefs(RelTraitDef... traitDefs) {
+      this.traitDefs = ImmutableList.copyOf(traitDefs);
+      return this;
+    }
+
+    public Builder lex(Lex lex) {
+      Preconditions.checkNotNull(lex);
+      this.lex = lex;
+      return this;
+    }
+
+    public Builder defaultSchema(SchemaPlus defaultSchema) {
+      this.defaultSchema = defaultSchema;
+      return this;
+    }
+
+    public Builder costFactory(RelOptCostFactory costFactory) {
+      this.costFactory = costFactory;
+      return this;
+    }
+
+    public Builder ruleSets(List<RuleSet> ruleSets) {
+      Preconditions.checkNotNull(ruleSets);
+      this.ruleSets = ImmutableList.copyOf(ruleSets);
+      return this;
+    }
+
+    public Builder ruleSets(RuleSet... ruleSets) {
+      this.ruleSets = ImmutableList.copyOf(ruleSets);
+      return this;
+    }
+
+    public Builder parserFactory(SqlParserImplFactory parserFactory) {
+      Preconditions.checkNotNull(parserFactory);
+      this.parserFactory = parserFactory;
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/AbstractRelOptPlanner.java
@@ -25,6 +25,8 @@ import org.eigenbase.rel.*;
 import org.eigenbase.rel.metadata.*;
 import org.eigenbase.util.*;
 
+import net.hydromatic.optiq.tools.FrameworkContext;
+
 import static org.eigenbase.util.Static.RESOURCE;
 
 /**
@@ -57,6 +59,8 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
 
   private final Set<RelTrait> traits = new HashSet<RelTrait>();
 
+  private final FrameworkContext context;
+
   private Executor executor;
 
   //~ Constructors -----------------------------------------------------------
@@ -64,8 +68,11 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
   /**
    * Creates an AbstractRelOptPlanner.
    */
-  protected AbstractRelOptPlanner(RelOptCostFactory costFactory) {
+  protected AbstractRelOptPlanner(RelOptCostFactory costFactory, //
+      FrameworkContext frameworkContext) {
+    assert costFactory != null;
     this.costFactory = costFactory;
+    this.context = frameworkContext;
     mapDescToRule = new HashMap<String, RelOptRule>();
 
     // In case no one calls setCancelFlag, set up a
@@ -76,6 +83,10 @@ public abstract class AbstractRelOptPlanner implements RelOptPlanner {
   //~ Methods ----------------------------------------------------------------
 
   public void clear() {}
+
+  public FrameworkContext getFrameworkContext() {
+    return context;
+  }
 
   public RelOptCostFactory getCostFactory() {
     return costFactory;

--- a/core/src/main/java/org/eigenbase/relopt/RelOptMaterialization.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptMaterialization.java
@@ -188,7 +188,8 @@ public class RelOptMaterialization {
         .addRuleInstance(PullUpProjectsAboveJoinRule.LEFT_PROJECT)
         .build();
     final HepPlanner planner =
-        new HepPlanner(program);
+        new HepPlanner(program, //
+            rel.getCluster().getPlanner().getFrameworkContext());
     planner.setRoot(rel);
     System.out.println(
         RelOptUtil.dumpPlan(

--- a/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptPlanner.java
@@ -28,6 +28,8 @@ import org.eigenbase.rex.RexNode;
 import org.eigenbase.trace.*;
 import org.eigenbase.util.*;
 
+import net.hydromatic.optiq.tools.FrameworkContext;
+
 /**
  * A <code>RelOptPlanner</code> is a query optimizer: it transforms a relational
  * expression into a semantically equivalent relational expression, according to
@@ -97,6 +99,12 @@ public interface RelOptPlanner {
    * java.util.Collection#remove(Object)}
    */
   boolean removeRule(RelOptRule rule);
+
+  /**
+   * Provides the FrameworkContext created when this planner was constructed.
+   * @return Either null or an externally defined Framework context.
+   */
+  FrameworkContext getFrameworkContext();
 
   /**
    * Sets the exclusion filter to use for this planner. Rules which match the

--- a/core/src/main/java/org/eigenbase/relopt/RelOptUtil.java
+++ b/core/src/main/java/org/eigenbase/relopt/RelOptUtil.java
@@ -1456,6 +1456,13 @@ public abstract class RelOptUtil {
       final String desc2,
       RelDataType type2,
       boolean fail) {
+
+    // if any one of the types is ANY return true
+    if (type1.getSqlTypeName() == SqlTypeName.ANY
+        || type2.getSqlTypeName() == SqlTypeName.ANY) {
+      return true;
+    }
+
     if (type1 != type2) {
       assert !fail : "type mismatch:\n"
           + desc1 + ":\n"

--- a/core/src/main/java/org/eigenbase/relopt/hep/HepPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/hep/HepPlanner.java
@@ -29,6 +29,7 @@ import org.eigenbase.util.*;
 import net.hydromatic.linq4j.function.Function2;
 import net.hydromatic.linq4j.function.Functions;
 
+import net.hydromatic.optiq.tools.FrameworkContext;
 import net.hydromatic.optiq.util.graph.*;
 
 import com.google.common.collect.ImmutableList;
@@ -77,7 +78,17 @@ public class HepPlanner extends AbstractRelOptPlanner {
    * @param program program controlling rule application
    */
   public HepPlanner(HepProgram program) {
-    this(program, false, null, RelOptCostImpl.FACTORY);
+    this(program, null, false, null, RelOptCostImpl.FACTORY);
+  }
+
+  /**
+   * Creates a new HepPlanner that allows DAG.
+   *
+   * @param program program controlling rule application
+   * @param context to carry while planning
+   */
+  public HepPlanner(HepProgram program, FrameworkContext context) {
+    this(program, context, false, null, RelOptCostImpl.FACTORY);
   }
 
   /**
@@ -89,10 +100,11 @@ public class HepPlanner extends AbstractRelOptPlanner {
    */
   public HepPlanner(
       HepProgram program,
+      FrameworkContext context,
       boolean noDAG,
       Function2<RelNode, RelNode, Void> onCopyHook,
       RelOptCostFactory costFactory) {
-    super(costFactory);
+    super(costFactory, context);
     this.mainProgram = program;
     this.onCopyHook =
         Util.first(onCopyHook, Functions.<RelNode, RelNode, Void>ignore2());

--- a/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/eigenbase/relopt/volcano/VolcanoPlanner.java
@@ -35,6 +35,7 @@ import org.eigenbase.util.*;
 import net.hydromatic.linq4j.expressions.Expressions;
 
 import net.hydromatic.optiq.runtime.Spaces;
+import net.hydromatic.optiq.tools.FrameworkContext;
 import net.hydromatic.optiq.util.graph.*;
 
 import com.google.common.collect.ImmutableList;
@@ -196,15 +197,26 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
    * calling conventions.
    */
   public VolcanoPlanner() {
-    this(VolcanoCost.FACTORY);
+    this(null, null);
+  }
+
+  /**
+   * Creates a uninitialized <code>VolcanoPlanner</code>. To fully initialize
+   * it, the caller must register the desired set of relations, rules, and
+   * calling conventions.
+   */
+  public VolcanoPlanner(FrameworkContext frameworkContext) {
+    this(null, frameworkContext);
   }
 
   /**
    * Creates a {@code VolcanoPlanner} with a given cost factory.
    */
-  protected VolcanoPlanner(RelOptCostFactory costFactory) {
-    super(costFactory);
-    this.zeroCost = costFactory.makeZeroCost();
+  public VolcanoPlanner(RelOptCostFactory costFactory, //
+      FrameworkContext frameworkContext) {
+    super(costFactory == null ? VolcanoCost.FACTORY : costFactory, //
+        frameworkContext);
+    this.zeroCost = this.costFactory.makeZeroCost();
   }
 
   //~ Methods ----------------------------------------------------------------
@@ -303,7 +315,8 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
             .addRuleInstance(MergeProjectRule.INSTANCE)
             .build();
 
-    final HepPlanner hepPlanner = new HepPlanner(program);
+    final HepPlanner hepPlanner = new HepPlanner(program, //
+        getFrameworkContext());
     hepPlanner.setRoot(target);
     target = hepPlanner.findBestExp();
 

--- a/core/src/main/java/org/eigenbase/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/RelDecorrelator.java
@@ -38,6 +38,7 @@ import org.eigenbase.util.mapping.Mappings;
 import net.hydromatic.linq4j.Ord;
 import net.hydromatic.linq4j.function.Function2;
 
+import net.hydromatic.optiq.tools.FrameworkContext;
 import net.hydromatic.optiq.util.BitSets;
 
 import com.google.common.collect.ImmutableSet;
@@ -73,6 +74,8 @@ public class RelDecorrelator implements ReflectiveVisitor {
   // The rel which is being visited
   private RelNode currentRel;
 
+  private final FrameworkContext frameworkContext;
+
   // maps built during decorrelation
   private final Map<RelNode, RelNode> mapOldToNewRel;
 
@@ -94,11 +97,13 @@ public class RelDecorrelator implements ReflectiveVisitor {
       RexBuilder rexBuilder,
       Map<RelNode, SortedSet<CorrelatorRel.Correlation>> mapRefRelToCorVar,
       SortedMap<CorrelatorRel.Correlation, CorrelatorRel> mapCorVarToCorRel,
-      Map<RexFieldAccess, CorrelatorRel.Correlation> mapFieldAccessToCorVar) {
+      Map<RexFieldAccess, CorrelatorRel.Correlation> mapFieldAccessToCorVar,
+      FrameworkContext frameworkContext) {
     this.rexBuilder = rexBuilder;
     this.mapRefRelToCorVar = mapRefRelToCorVar;
     this.mapCorVarToCorRel = mapCorVarToCorRel;
     this.mapFieldAccessToCorVar = mapFieldAccessToCorVar;
+    this.frameworkContext = frameworkContext;
 
     decorrelateVisitor = new DecorrelateRelVisitor();
     mapOldToNewRel = new HashMap<RelNode, RelNode>();
@@ -169,6 +174,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
     // node is copied when it is registered.
     return new HepPlanner(
         program,
+        frameworkContext,
         true,
         createCopyHook(),
         RelOptCostImpl.FACTORY);

--- a/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/eigenbase/sql2rel/SqlToRelConverter.java
@@ -2729,7 +2729,8 @@ public class SqlToRelConverter {
             rexBuilder,
             mapRefRelToCorVar,
             mapCorVarToCorRel,
-            mapFieldAccessToCorVar);
+            mapFieldAccessToCorVar,
+            cluster.getPlanner().getFrameworkContext());
     boolean dumpPlan = SQL2REL_LOGGER.isLoggable(Level.FINE);
 
     RelNode newRootRel = decorrelator.removeCorrelationViaRule(rootRel);

--- a/core/src/test/java/org/eigenbase/test/MockRelOptPlanner.java
+++ b/core/src/test/java/org/eigenbase/test/MockRelOptPlanner.java
@@ -45,7 +45,7 @@ public class MockRelOptPlanner extends AbstractRelOptPlanner {
 
   /** Creates MockRelOptPlanner. */
   public MockRelOptPlanner() {
-    super(RelOptCostImpl.FACTORY);
+    super(RelOptCostImpl.FACTORY, null);
     setExecutor(new RexExecutorImpl(Schemas.createDataContext(null)));
   }
 


### PR DESCRIPTION
Allow RelOptCostFactory to be replaced.  Make getPlanner() cleaner by using configuration object and builder pattern.
