### PR TITLE
Create root schema without the "metadata" schema 

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
@@ -78,7 +78,7 @@ abstract class OptiqConnectionImpl
     this.typeFactory =
         typeFactory != null ? typeFactory : new JavaTypeFactoryImpl();
     this.rootSchema =
-        rootSchema != null ? rootSchema : OptiqSchema.createRootSchema();
+        rootSchema != null ? rootSchema : OptiqSchema.createRootSchema(true);
 
     OptiqConnectionConfig cfg = new OptiqConnectionConfigImpl(info);
     this.properties.put(InternalProperty.CASE_SENSITIVE, cfg.caseSensitive());

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqSchema.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqSchema.java
@@ -103,12 +103,15 @@ public class OptiqSchema {
         };
   }
 
-  /** Creates a root schema. It contains a "metadata" schema containing
-   * definitions of tables, columns etc. */
-  public static OptiqRootSchema createRootSchema() {
+  /** Creates a root schema. When {@paramref addMetadataSchema} is true a
+   * "metadata" schema containing definitions of tables, columns etc. is added
+   * to root schema. */
+  public static OptiqRootSchema createRootSchema(boolean addMetadataSchema) {
     OptiqRootSchema rootSchema =
         new OptiqRootSchema(new OptiqConnectionImpl.RootSchema());
-    rootSchema.add("metadata", MetadataSchema.INSTANCE);
+    if (addMetadataSchema) {
+      rootSchema.add("metadata", MetadataSchema.INSTANCE);
+    }
     return rootSchema;
   }
 

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqSchema.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqSchema.java
@@ -103,9 +103,9 @@ public class OptiqSchema {
         };
   }
 
-  /** Creates a root schema. When {@paramref addMetadataSchema} is true a
-   * "metadata" schema containing definitions of tables, columns etc. is added
-   * to root schema. */
+  /** Creates a root schema. When <code>addMetadataSchema</code> argument is
+   * true a "metadata" schema containing definitions of tables, columns etc. is
+   * added to root schema. */
   public static OptiqRootSchema createRootSchema(boolean addMetadataSchema) {
     OptiqRootSchema rootSchema =
         new OptiqRootSchema(new OptiqConnectionImpl.RootSchema());

--- a/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
+++ b/core/src/main/java/net/hydromatic/optiq/tools/Frameworks.java
@@ -173,9 +173,12 @@ public class Frameworks {
 
   /**
    * Creates a root schema.
+   *
+   * @param addMetadataSchema Whether to add "metadata" schema containing
+   *    definitions of tables, columns etc.
    */
-  public static SchemaPlus createRootSchema() {
-    return OptiqSchema.createRootSchema().plus();
+  public static SchemaPlus createRootSchema(boolean addMetadataSchema) {
+    return OptiqSchema.createRootSchema(addMetadataSchema).plus();
   }
 }
 

--- a/core/src/test/java/net/hydromatic/optiq/tools/FrameworksTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/tools/FrameworksTest.java
@@ -105,6 +105,12 @@ public class FrameworksTest {
         "EnumerableFilterRel(condition=[>($1, 1)])\n"
         + "  EnumerableTableAccessRel(table=[[myTable]])\n"));
   }
+
+  /** Unit test to test create root schema which has no "metadata" schema. */
+  @Test public void testCreateRootSchemaWithNoMetadataSchema() {
+    SchemaPlus rootSchema = Frameworks.createRootSchema(false);
+    assertTrue(rootSchema.getSubSchemaNames().size() == 0);
+  }
 }
 
 // End FrameworksTest.java

--- a/core/src/test/java/net/hydromatic/optiq/tools/FrameworksTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/tools/FrameworksTest.java
@@ -109,7 +109,7 @@ public class FrameworksTest {
   /** Unit test to test create root schema which has no "metadata" schema. */
   @Test public void testCreateRootSchemaWithNoMetadataSchema() {
     SchemaPlus rootSchema = Frameworks.createRootSchema(false);
-    assertTrue(rootSchema.getSubSchemaNames().size() == 0);
+    assertThat(rootSchema.getSubSchemaNames().size(), equalTo(0));
   }
 }
 

--- a/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/tools/PlannerTest.java
@@ -174,7 +174,7 @@ public class PlannerTest {
   }
 
   private SchemaPlus createHrSchema() {
-    return Frameworks.createRootSchema().add("hr",
+    return Frameworks.createRootSchema(true).add("hr",
         new ReflectiveSchema(new JdbcTest.HrSchema()));
   }
 
@@ -528,7 +528,7 @@ public class PlannerTest {
 
   public String checkTpchQuery(String tpchTestQuery) throws Exception {
     final SchemaPlus schema =
-        Frameworks.createRootSchema().add("tpch",
+        Frameworks.createRootSchema(true).add("tpch",
             new ReflectiveSchema(new TpchSchema()));
 
     Planner p = Frameworks.getPlanner(Lex.MYSQL, schema,


### PR DESCRIPTION
Root schema returned by `Frameworks.createRootSchema` contains `metadata` subschema. For some clients `metadata` schema is not needed. For example in Drill metadata is managed by INFORMATION_SCHEMA which is added as subschema to root schema.

Is it a good idea to pass a flag to `Frameworks.createRootSchema` to indicate whether `metadata` schema is expected or not in root schema?
