### PR TITLE
Implement table functions.

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/BuiltinMethod.java
+++ b/core/src/main/java/net/hydromatic/optiq/BuiltinMethod.java
@@ -49,6 +49,8 @@ import static org.eigenbase.rel.metadata.BuiltInMetadata.*;
 public enum BuiltinMethod {
   QUERYABLE_SELECT(Queryable.class, "select", FunctionExpression.class),
   QUERYABLE_AS_ENUMERABLE(Queryable.class, "asEnumerable"),
+  QUERYABLE_TABLE_AS_QUERYABLE(QueryableTable.class, "asQueryable",
+      QueryProvider.class, SchemaPlus.class, String.class),
   AS_QUERYABLE(Enumerable.class, "asQueryable"),
   ABSTRACT_ENUMERABLE_CTOR(AbstractEnumerable.class),
   INTO(ExtendedEnumerable.class, "into", Collection.class),
@@ -209,6 +211,7 @@ public enum BuiltinMethod {
   NON_CUMULATIVE_COST(NonCumulativeCost.class, "getNonCumulativeCost"),
   EXPLAIN_VISIBILITY(ExplainVisibility.class, "isVisibleInExplain",
       SqlExplainLevel.class),
+  DATA_CONTEXT_GET_QUERY_PROVIDER(DataContext.class, "getQueryProvider"),
   METADATA_REL(Metadata.class, "rel");
 
   public final Method method;

--- a/core/src/main/java/net/hydromatic/optiq/ImplementableFunction.java
+++ b/core/src/main/java/net/hydromatic/optiq/ImplementableFunction.java
@@ -17,23 +17,20 @@
 */
 package net.hydromatic.optiq;
 
-import java.util.List;
+import net.hydromatic.optiq.rules.java.CallImplementor;
 
 /**
- * Function that returns a {@link Table}.
- *
- * <p>As the name "macro" implies, this is invoked at "compile time", that is,
- * during query preparation. Compile-time expansion of table expressions allows
- * for some very powerful query-optimizations.</p>
+ * Function that can be translated to java code.
+ * <p>
+ * @see net.hydromatic.optiq.ScalarFunction
+ * @see net.hydromatic.optiq.TableFunction
  */
-public interface TableMacro extends Function {
+public interface ImplementableFunction extends Function {
   /**
-   * Applies arguments to yield a table.
-   *
-   * @param arguments Arguments
-   * @return Table
+   * Returns implementor that translates the function to linq4j expression.
+   * @return implementor that translates the function to linq4j expression.
    */
-  TranslatableTable apply(List<Object> arguments);
+  CallImplementor getImplementor();
 }
 
-// End TableMacro.java
+// End ImplementableFunction.java

--- a/core/src/main/java/net/hydromatic/optiq/TableFunction.java
+++ b/core/src/main/java/net/hydromatic/optiq/TableFunction.java
@@ -1,0 +1,58 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Function that returns a table during execution time.
+ * <p>
+ * In contrast with {@code TableMacro}, the result of the table is not known
+ * until execution.
+ */
+public interface TableFunction extends Function {
+  /**
+   * Returns the record type of the table yielded by this function when
+   * applied to given arguments. Only literal arguments are passed,
+   * non-literal are replaced with default values (null, 0, false, etc).
+   *
+   * @param typeFactory Type factory
+   * @param arguments arguments of a function call (only literal arguments
+   *                  are passed, nulls for non-literal ones)
+   * @return row type of the table
+   */
+  RelDataType getRowType(RelDataTypeFactory typeFactory,
+    List<Object> arguments);
+
+  /**
+   * Returns the row type of the table yielded by this function when
+   * applied to given arguments. Only literal arguments are passed,
+   * non-literal are replaced with default values (null, 0, false, etc).
+   *
+   * @param arguments arguments of a function call (only literal arguments
+   *                  are passed, nulls for non-literal ones)
+   * @return element type of the table (e.g. {@code Object[].class})
+   */
+  Type getElementType(List<Object> arguments);
+}
+
+// End TableFunction.java

--- a/core/src/main/java/net/hydromatic/optiq/impl/MaterializedViewTable.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/MaterializedViewTable.java
@@ -109,7 +109,7 @@ public class MaterializedViewTable extends ViewTable {
     }
 
     @Override
-    public Table apply(List<Object> arguments) {
+    public TranslatableTable apply(List<Object> arguments) {
       assert arguments.isEmpty();
       OptiqPrepare.ParseResult parsed =
           Schemas.parse(MATERIALIZATION_CONNECTION, schema, schemaPath,

--- a/core/src/main/java/net/hydromatic/optiq/impl/ReflectiveFunctionBase.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/ReflectiveFunctionBase.java
@@ -1,0 +1,126 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.impl;
+
+import net.hydromatic.optiq.Function;
+import net.hydromatic.optiq.FunctionParameter;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+
+import com.google.common.collect.ImmutableList;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Implementation of a function that is based on a method.
+ * This class mainly solves conversion of method parameter types to {@code
+ * List<FunctionParameter>} form.
+ */
+public abstract class ReflectiveFunctionBase implements Function {
+  /** Method that implements the function. */
+  public final Method method;
+  /** Types of parameter for the function call. */
+  public final List<FunctionParameter> parameters;
+
+  /**
+   * {@code ReflectiveFunctionBase} constructor
+   * @param method method that is used to get type information from
+   */
+  public ReflectiveFunctionBase(Method method) {
+    this.method = method;
+    this.parameters = toFunctionParameters(method.getParameterTypes());
+  }
+
+  /**
+   * Returns the parameters of this function.
+   *
+   * @return Parameters; never null
+   */
+  public List<FunctionParameter> getParameters() {
+    return parameters;
+  }
+
+
+  public static ImmutableList<FunctionParameter> toFunctionParameters(
+      Class... types) {
+    return toFunctionParameters(Arrays.asList(types));
+  }
+
+  public static ImmutableList<FunctionParameter> toFunctionParameters(
+      Iterable<? extends Class> types) {
+    final ImmutableList.Builder<FunctionParameter> res =
+        ImmutableList.builder();
+    int i = 0;
+    for (final Class type : types) {
+      final int ordinal = i;
+      res.add(new FunctionParameter() {
+        public int getOrdinal() {
+          return ordinal;
+        }
+
+        public String getName() {
+          return "arg"  + ordinal;
+        }
+
+        public RelDataType getType(RelDataTypeFactory typeFactory) {
+          return typeFactory.createJavaType(type);
+        }
+      });
+      i++;
+    }
+    return res.build();
+  }
+
+  /**
+   * Verifies if given class has public constructor with zero arguments.
+   * @param clazz class to verify
+   * @return true if given class has public constructor with zero arguments
+   */
+  static boolean classHasPublicZeroArgsConstructor(Class<?> clazz) {
+    for (Constructor<?> constructor : clazz.getConstructors()) {
+      if (constructor.getParameterTypes().length == 0
+          && (constructor.getModifiers() & Modifier.PUBLIC) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Finds a method in a given class by name.
+   * @param clazz class to search method in
+   * @param name name of the method to find
+   * @return the first method with matching name or null when no method found
+   */
+  static Method findMethod(Class<?> clazz, String name) {
+    for (Method method : clazz.getMethods()) {
+      if (method.getName().equals(name)) {
+        return method;
+      }
+    }
+    return null;
+  }
+}
+
+// End ReflectiveFunctionBase.java
+

--- a/core/src/main/java/net/hydromatic/optiq/impl/ScalarFunctionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/ScalarFunctionImpl.java
@@ -19,91 +19,74 @@ package net.hydromatic.optiq.impl;
 
 import net.hydromatic.optiq.*;
 
+import net.hydromatic.optiq.rules.java.*;
+
 import org.eigenbase.reltype.RelDataType;
 import org.eigenbase.reltype.RelDataTypeFactory;
 
 import java.lang.reflect.*;
-import java.util.AbstractList;
-import java.util.List;
 
 import static org.eigenbase.util.Static.*;
 
 /**
 * Implementation of {@link net.hydromatic.optiq.ScalarFunction}.
 */
-public class ScalarFunctionImpl implements ScalarFunction {
-  public final Method method;
+public class ScalarFunctionImpl extends ReflectiveFunctionBase implements
+    ScalarFunction, ImplementableFunction {
+  private final CallImplementor implementor;
 
   /** Private constructor. */
-  private ScalarFunctionImpl(Method method) {
-    this.method = method;
+  private ScalarFunctionImpl(Method method, CallImplementor implementor) {
+    super(method);
+    this.implementor = implementor;
   }
 
-  /** Creates a scalar function.
+  /**
+   * Creates {@link net.hydromatic.optiq.ScalarFunction} from given class.
+   * The class should contain {@code eval} method.
+   * When {@code eval} method is not found or it does not suit,
+   * {@code null} is returned.
    *
-   * @see TableMacroImpl#create(Class)
+   * @param clazz class that is used to implement the function
+   * @return created {@link ScalarFunction} or null
    */
   public static ScalarFunction create(Class<?> clazz) {
     final Method method = findMethod(clazz, "eval");
-    if (method != null) {
-      if ((method.getModifiers() & Modifier.STATIC) == 0) {
-        if (!classHasPublicZeroArgsConstructor(clazz)) {
-          throw RESOURCE.requireDefaultConstructor(clazz.getName()).ex();
-        }
-      }
-      // NOTE: scalar functions and table macros look similar. It is important
-      // to check for table macros FIRST.
-      return new ScalarFunctionImpl(method);
+    if (method == null) {
+      return null;
     }
-    return null;
+    return create(method);
   }
 
-  static boolean classHasPublicZeroArgsConstructor(Class<?> clazz) {
-    for (Constructor<?> constructor : clazz.getConstructors()) {
-      if (constructor.getParameterTypes().length == 0
-          && (constructor.getModifiers() & Modifier.PUBLIC) != 0) {
-        return true;
+  /**
+   * Creates {@link net.hydromatic.optiq.ScalarFunction} from given method.
+   * When {@code eval} method does not suit, {@code null} is returned.
+   *
+   * @param method method that is used to implement the function
+   * @return created {@link ScalarFunction} or null
+   */
+  public static ScalarFunction create(Method method) {
+    if (!Modifier.isStatic(method.getModifiers())) {
+      Class clazz = method.getDeclaringClass();
+      if (!classHasPublicZeroArgsConstructor(clazz)) {
+        throw RESOURCE.requireDefaultConstructor(clazz.getName()).ex();
       }
     }
-    return false;
-  }
-
-  static Method findMethod(Class<?> clazz, String name) {
-    for (Method method : clazz.getMethods()) {
-      if (method.getName().equals(name)) {
-        return method;
-      }
-    }
-    return null;
-  }
-
-  public List<FunctionParameter> getParameters() {
-    final Class<?>[] parameterTypes = method.getParameterTypes();
-    return new AbstractList<FunctionParameter>() {
-      public FunctionParameter get(final int index) {
-        return new FunctionParameter() {
-          public int getOrdinal() {
-            return index;
-          }
-
-          public String getName() {
-            return "arg" + index;
-          }
-
-          public RelDataType getType(RelDataTypeFactory typeFactory) {
-            return typeFactory.createJavaType(parameterTypes[index]);
-          }
-        };
-      }
-
-      public int size() {
-        return parameterTypes.length;
-      }
-    };
+    CallImplementor implementor = createImplementor(method);
+    return new ScalarFunctionImpl(method, implementor);
   }
 
   public RelDataType getReturnType(RelDataTypeFactory typeFactory) {
     return typeFactory.createJavaType(method.getReturnType());
+  }
+
+  public CallImplementor getImplementor() {
+    return implementor;
+  }
+
+  private static CallImplementor createImplementor(final Method method) {
+    return RexImpTable.createImplementor(new ReflectiveCallNotNullImplementor(
+        method), NullPolicy.ANY, false);
   }
 }
 

--- a/core/src/main/java/net/hydromatic/optiq/impl/TableFunctionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/TableFunctionImpl.java
@@ -1,0 +1,139 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.impl;
+
+import net.hydromatic.linq4j.expressions.Expression;
+import net.hydromatic.linq4j.expressions.Expressions;
+
+import net.hydromatic.optiq.*;
+import net.hydromatic.optiq.rules.java.*;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+import org.eigenbase.rex.RexCall;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.eigenbase.util.Static.RESOURCE;
+
+/**
+ * Implementation of {@link net.hydromatic.optiq.TableFunction} based on a
+ * method.
+*/
+public class TableFunctionImpl extends ReflectiveFunctionBase implements
+    TableFunction, ImplementableFunction {
+  private final CallImplementor implementor;
+
+  /** Private constructor; use {@link #create}. */
+  private TableFunctionImpl(Method method, CallImplementor implementor) {
+    super(method);
+    this.implementor = implementor;
+  }
+
+  /** Creates a {@link TableFunctionImpl} from a class, looking for an "eval"
+   * method. Returns null if there is no such method. */
+  public static TableFunction create(Class<?> clazz) {
+    final Method method = findMethod(clazz, "eval");
+    if (method == null) {
+      return null;
+    }
+    return create(method);
+  }
+
+  /** Creates a {@link TableFunctionImpl} from a method. */
+  public static TableFunction create(final Method method) {
+    if (!Modifier.isStatic(method.getModifiers())) {
+      Class clazz = method.getDeclaringClass();
+      if (!classHasPublicZeroArgsConstructor(clazz)) {
+        throw RESOURCE.requireDefaultConstructor(clazz.getName()).ex();
+      }
+    }
+    final Class<?> returnType = method.getReturnType();
+    if (!QueryableTable.class.isAssignableFrom(returnType)) {
+      return null;
+    }
+    CallImplementor implementor = createImplementor(method);
+    return new TableFunctionImpl(method, implementor);
+  }
+
+  public RelDataType getRowType(RelDataTypeFactory typeFactory,
+      List<Object> arguments) {
+    return apply(arguments).getRowType(typeFactory);
+  }
+
+  public Type getElementType(List<Object> arguments) {
+    return apply(arguments).getElementType();
+  }
+
+  public CallImplementor getImplementor() {
+    return implementor;
+  }
+
+  private static CallImplementor createImplementor(final Method method) {
+    return RexImpTable.createImplementor(new ReflectiveCallNotNullImplementor(
+        method) {
+      public Expression implement(RexToLixTranslator translator,
+          RexCall call, List<Expression> translatedOperands) {
+        Expression expr = super.implement(translator, call,
+            translatedOperands);
+        Expression queryable = Expressions.call(
+          Expressions.convert_(expr, QueryableTable.class),
+          BuiltinMethod.QUERYABLE_TABLE_AS_QUERYABLE.method,
+          Expressions.call(DataContext.ROOT,
+            BuiltinMethod.DATA_CONTEXT_GET_QUERY_PROVIDER.method),
+          Expressions.constant(null, SchemaPlus.class),
+          Expressions.constant(call.getOperator().getName(),
+            String.class));
+        expr = Expressions.call(queryable,
+            BuiltinMethod.QUERYABLE_AS_ENUMERABLE.method);
+        return expr;
+      }
+    }, NullPolicy.ANY, false);
+  }
+
+  private QueryableTable apply(List<Object> arguments) {
+    try {
+      Object o = null;
+      if (!Modifier.isStatic(method.getModifiers())) {
+        o = method.getDeclaringClass().newInstance();
+      }
+      //noinspection unchecked
+      final Object table = method.invoke(o, arguments.toArray());
+      return (QueryableTable) table;
+    } catch (IllegalArgumentException e) {
+      throw RESOURCE.illegalArgumentForTableFunctionCall(
+          method.toString(),
+          Arrays.asList(method.getParameterTypes()).toString(),
+          arguments.toString()
+      ).ex(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    } catch (InstantiationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}
+
+// End TableFunctionImpl.java

--- a/core/src/main/java/net/hydromatic/optiq/impl/ViewTable.java
+++ b/core/src/main/java/net/hydromatic/optiq/impl/ViewTable.java
@@ -123,7 +123,7 @@ public class ViewTable
       return Collections.emptyList();
     }
 
-    public Table apply(List<Object> arguments) {
+    public TranslatableTable apply(List<Object> arguments) {
       OptiqPrepare.ParseResult parsed =
           Schemas.parse(MATERIALIZATION_CONNECTION, schema, schemaPath,
               viewSql);
@@ -132,10 +132,6 @@ public class ViewTable
       final JavaTypeFactory typeFactory = (JavaTypeFactory) parsed.typeFactory;
       return new ViewTable(typeFactory.getJavaClass(parsed.rowType),
           RelDataTypeImpl.proto(parsed.rowType), viewSql, schemaPath1);
-    }
-
-    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-      return apply(Collections.emptyList()).getRowType(typeFactory);
     }
   }
 }

--- a/core/src/main/java/net/hydromatic/optiq/model/ModelHandler.java
+++ b/core/src/main/java/net/hydromatic/optiq/model/ModelHandler.java
@@ -76,6 +76,10 @@ public class ModelHandler {
     }
     // Must look for TableMacro before ScalarFunction. Both have an "eval"
     // method.
+    final TableFunction tableFunction = TableFunctionImpl.create(clazz);
+    if (tableFunction != null) {
+      return tableFunction;
+    }
     final TableMacro macro = TableMacroImpl.create(clazz);
     if (macro != null) {
       return macro;

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqCatalogReader.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqCatalogReader.java
@@ -40,7 +40,8 @@ import java.util.*;
  * and also {@link org.eigenbase.sql.SqlOperatorTable} based on tables and
  * functions defined schemas.
  */
-class OptiqCatalogReader implements Prepare.CatalogReader, SqlOperatorTable {
+public class OptiqCatalogReader implements Prepare.CatalogReader,
+    SqlOperatorTable {
   final OptiqSchema rootSchema;
   final JavaTypeFactory typeFactory;
   private final List<String> defaultSchema;
@@ -209,10 +210,15 @@ class OptiqCatalogReader implements Prepare.CatalogReader, SqlOperatorTable {
           ReturnTypes.explicit(returnType), InferTypes.explicit(argTypes),
           OperandTypes.family(typeFamilies), (AggregateFunction) function);
     } else if (function instanceof TableMacro) {
-      return new SqlUserDefinedFunction(name,
-          ReturnTypes.explicit(SqlTypeName.CURSOR),
+      return new SqlUserDefinedTableMacro(name,
+          ReturnTypes.CURSOR,
           InferTypes.explicit(argTypes), OperandTypes.family(typeFamilies),
-          function);
+          (TableMacro) function);
+    } else if (function instanceof TableFunction) {
+      return new SqlUserDefinedTableFunction(name,
+          ReturnTypes.CURSOR,
+          InferTypes.explicit(argTypes), OperandTypes.family(typeFamilies),
+          (TableFunction) function);
     } else {
       throw new AssertionError("unknown function type " + function);
     }

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqMaterializer.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqMaterializer.java
@@ -132,6 +132,9 @@ class OptiqMaterializer extends OptiqPrepareImpl.OptiqPreparingStmt {
     public RelNode visit(TableAccessRelBase scan) {
       return scan;
     }
+    public RelNode visit(TableFunctionRelBase scan) {
+      return scan;
+    }
     public RelNode visit(ValuesRel values) {
       return values;
     }

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqPrepareImpl.java
@@ -169,6 +169,7 @@ public class OptiqPrepareImpl implements OptiqPrepare {
     planner.addRule(JavaRules.ENUMERABLE_WINDOW_RULE);
     planner.addRule(JavaRules.ENUMERABLE_ONE_ROW_RULE);
     planner.addRule(JavaRules.ENUMERABLE_EMPTY_RULE);
+    planner.addRule(JavaRules.ENUMERABLE_TABLE_FUNCTION_RULE);
     planner.addRule(TableAccessRule.INSTANCE);
     planner.addRule(MergeProjectRule.INSTANCE);
     planner.addRule(PushFilterPastProjectRule.INSTANCE);

--- a/core/src/main/java/net/hydromatic/optiq/rules/java/CallImplementor.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/CallImplementor.java
@@ -15,25 +15,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-package net.hydromatic.optiq;
+package net.hydromatic.optiq.rules.java;
 
-import java.util.List;
+import net.hydromatic.linq4j.expressions.Expression;
+
+import org.eigenbase.rex.RexCall;
 
 /**
- * Function that returns a {@link Table}.
- *
- * <p>As the name "macro" implies, this is invoked at "compile time", that is,
- * during query preparation. Compile-time expansion of table expressions allows
- * for some very powerful query-optimizations.</p>
+ * Implements a call via given translator.
+ * <p>
+ * @see net.hydromatic.optiq.ScalarFunction
+ * @see net.hydromatic.optiq.TableFunction
+ * @see net.hydromatic.optiq.rules.java.RexImpTable
  */
-public interface TableMacro extends Function {
-  /**
-   * Applies arguments to yield a table.
-   *
-   * @param arguments Arguments
-   * @return Table
-   */
-  TranslatableTable apply(List<Object> arguments);
+public interface CallImplementor {
+  /** Implements a call. */
+  Expression implement(
+      RexToLixTranslator translator,
+      RexCall call,
+      RexImpTable.NullAs nullAs);
 }
-
-// End TableMacro.java

--- a/core/src/main/java/net/hydromatic/optiq/rules/java/NotNullImplementor.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/NotNullImplementor.java
@@ -1,0 +1,50 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.rules.java;
+
+import net.hydromatic.linq4j.expressions.Expression;
+
+import org.eigenbase.rex.RexCall;
+
+import java.util.List;
+
+/**
+ * Simplified version of {@link net.hydromatic.optiq.rules.java.CallImplementor} that does not know about
+ * null semantics.
+ * <p>
+ * @see net.hydromatic.optiq.rules.java.RexImpTable
+ * @see net.hydromatic.optiq.rules.java.CallImplementor
+ *
+ **/
+public interface NotNullImplementor {
+  /**
+   * Implements a call with assumption that all the null-checking is
+   * implemented by caller.
+   * <p>
+   * @param translator translator to implement the code
+   * @param call call to implement
+   * @param translatedOperands arguments of a call
+   * @return expression that implements given call
+   */
+  Expression implement(
+      RexToLixTranslator translator,
+      RexCall call,
+      List<Expression> translatedOperands);
+}
+
+// End NotNullImplementor.java

--- a/core/src/main/java/net/hydromatic/optiq/rules/java/NullPolicy.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/NullPolicy.java
@@ -1,0 +1,43 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.rules.java;
+
+/**
+ * Describes when a function/operator will return null.
+ *
+ * <p>STRICT and ANY are similar. STRICT says f(a0, a1) will NEVER return
+ * null if a0 and a1 are not null. This means that we can check whether f
+ * returns null just by checking its arguments. Use STRICT in preference to
+ * ANY whenever possible.</p>
+ */
+public enum NullPolicy {
+  /** Returns null if and only if one of the arguments are null. */
+  STRICT,
+  /** If any of the arguments are null, return null. */
+  ANY,
+  /** If any of the arguments are false, result is false; else if any
+   * arguments are null, result is null; else true. */
+  AND,
+  /** If any of the arguments are true, result is true; else if any
+   * arguments are null, result is null; else false. */
+  OR,
+  /** If any argument is true, result is false; else if any argument is null,
+   * result is null; else true. */
+  NOT,
+  NONE
+}

--- a/core/src/main/java/net/hydromatic/optiq/rules/java/ReflectiveCallNotNullImplementor.java
+++ b/core/src/main/java/net/hydromatic/optiq/rules/java/ReflectiveCallNotNullImplementor.java
@@ -1,0 +1,60 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.rules.java;
+
+import net.hydromatic.linq4j.expressions.Expression;
+import net.hydromatic.linq4j.expressions.Expressions;
+import net.hydromatic.linq4j.expressions.NewExpression;
+
+import org.eigenbase.rex.RexCall;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+/**
+ * Implementation of {@link net.hydromatic.optiq.rules.java
+ * .NotNullImplementor} that calls given {@link java.lang.reflect.Method}.
+ * When method is not static, a new instance of the required class is created.
+ */
+public class ReflectiveCallNotNullImplementor implements NotNullImplementor {
+  protected final Method method;
+
+  /**
+   * Constructor of {@link ReflectiveCallNotNullImplementor}
+   * @param method method that is used to implement the call
+   */
+  public ReflectiveCallNotNullImplementor(Method method) {
+    this.method = method;
+  }
+
+  public Expression implement(RexToLixTranslator translator,
+      RexCall call, List<Expression> translatedOperands) {
+    if ((method.getModifiers() & Modifier.STATIC) != 0) {
+      return Expressions.call(method, translatedOperands);
+    } else {
+      // The UDF class must have a public zero-args constructor.
+      // Assume that the validator checked already.
+      final NewExpression target =
+          Expressions.new_(method.getDeclaringClass());
+      return Expressions.call(target, method, translatedOperands);
+    }
+  }
+}
+
+// End ReflectiveCallNotNullImplementor.java

--- a/core/src/main/java/org/eigenbase/rel/RelShuttle.java
+++ b/core/src/main/java/org/eigenbase/rel/RelShuttle.java
@@ -23,6 +23,8 @@ package org.eigenbase.rel;
 public interface RelShuttle {
   RelNode visit(TableAccessRelBase scan);
 
+  RelNode visit(TableFunctionRelBase scan);
+
   RelNode visit(ValuesRel values);
 
   RelNode visit(FilterRel filter);

--- a/core/src/main/java/org/eigenbase/rel/RelShuttleImpl.java
+++ b/core/src/main/java/org/eigenbase/rel/RelShuttleImpl.java
@@ -67,6 +67,10 @@ public class RelShuttleImpl implements RelShuttle {
     return scan;
   }
 
+  public RelNode visit(TableFunctionRelBase scan) {
+    return visitChildren(scan);
+  }
+
   public RelNode visit(ValuesRel values) {
     return values;
   }

--- a/core/src/main/java/org/eigenbase/rel/TableFunctionRel.java
+++ b/core/src/main/java/org/eigenbase/rel/TableFunctionRel.java
@@ -17,6 +17,7 @@
 */
 package org.eigenbase.rel;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 
@@ -39,6 +40,8 @@ public class TableFunctionRel extends TableFunctionRelBase {
    * @param cluster        Cluster that this relational expression belongs to
    * @param inputs         0 or more relational inputs
    * @param rexCall        function invocation expression
+   * @param elementType    element type of the collection that will implement
+   *                       this table
    * @param rowType        row type produced by function
    * @param columnMappings column mappings associated with this function
    */
@@ -46,13 +49,14 @@ public class TableFunctionRel extends TableFunctionRelBase {
       RelOptCluster cluster,
       List<RelNode> inputs,
       RexNode rexCall,
-      RelDataType rowType,
+      Type elementType, RelDataType rowType,
       Set<RelColumnMapping> columnMappings) {
     super(
         cluster,
         cluster.traitSetOf(Convention.NONE),
         inputs,
         rexCall,
+        elementType,
         rowType,
         columnMappings);
   }
@@ -73,7 +77,7 @@ public class TableFunctionRel extends TableFunctionRelBase {
         getCluster(),
         inputs,
         getCall(),
-        getRowType(),
+        getElementType(), getRowType(),
         columnMappings);
   }
 

--- a/core/src/main/java/org/eigenbase/rel/rules/PushFilterPastTableFunctionRule.java
+++ b/core/src/main/java/org/eigenbase/rel/rules/PushFilterPastTableFunctionRule.java
@@ -106,7 +106,7 @@ public class PushFilterPastTableFunctionRule extends RelOptRule {
             cluster,
             newFuncInputs,
             funcRel.getCall(),
-            funcRel.getRowType(),
+            funcRel.getElementType(), funcRel.getRowType(),
             columnMappings);
     call.transformTo(newFuncRel);
   }

--- a/core/src/main/java/org/eigenbase/resource/EigenbaseNewResource.java
+++ b/core/src/main/java/org/eigenbase/resource/EigenbaseNewResource.java
@@ -436,6 +436,10 @@ public interface EigenbaseNewResource {
   ExInst<SqlValidatorException> argumentMustBeValidPrecision(String a0, int a1,
       int a2);
 
+  @BaseMessage("Wrong arguments for table function ''{0}'' call. Expected ''{1}'', actual ''{2}''")
+  ExInst<EigenbaseException> illegalArgumentForTableFunctionCall(String a0,
+      String a1, String a2);
+
   @BaseMessage("''{0}'' is not a valid datetime format")
   ExInst<EigenbaseException> invalidDatetimeFormat(String a0);
 

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedTableFunction.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedTableFunction.java
@@ -1,0 +1,93 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.sql.validate;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+import org.eigenbase.sql.SqlIdentifier;
+import org.eigenbase.sql.SqlNode;
+import org.eigenbase.sql.type.SqlOperandTypeChecker;
+import org.eigenbase.sql.type.SqlOperandTypeInference;
+import org.eigenbase.sql.type.SqlReturnTypeInference;
+
+import net.hydromatic.optiq.TableFunction;
+
+/**
+ * User-defined table function.
+ * <p>
+ * Created by the validator, after resolving a function call to a function
+ * defined in an Optiq schema.
+*/
+public class SqlUserDefinedTableFunction extends SqlUserDefinedFunction {
+  public SqlUserDefinedTableFunction(SqlIdentifier opName,
+        SqlReturnTypeInference returnTypeInference,
+        SqlOperandTypeInference operandTypeInference,
+        SqlOperandTypeChecker operandTypeChecker,
+        TableFunction function) {
+    super(opName, returnTypeInference, operandTypeInference, operandTypeChecker,
+            function);
+  }
+
+  /**
+   * Returns function that implements given operator call.
+   * @return function that implements given operator call
+   */
+  public TableFunction getFunction() {
+    return (TableFunction) super.getFunction();
+  }
+
+  /**
+   * Returns the record type of the table yielded by this function when
+   * applied to given arguments. Only literal arguments are passed,
+   * non-literal are replaced with default values (null, 0, false, etc).
+   *
+   * @param typeFactory Type factory
+   * @param operandList arguments of a function call (only literal arguments
+   *                    are passed, nulls for non-literal ones)
+   * @return row type of the table
+   */
+  public RelDataType getRowType(RelDataTypeFactory typeFactory,
+      List<SqlNode> operandList) {
+    List<Object> arguments =
+      SqlUserDefinedTableMacro.convertArguments(typeFactory, operandList,
+        function, getNameAsId(), false);
+    return getFunction().getRowType(typeFactory, arguments);
+  }
+
+  /**
+   * Returns the row type of the table yielded by this function when
+   * applied to given arguments. Only literal arguments are passed,
+   * non-literal are replaced with default values (null, 0, false, etc).
+   *
+   * @param operandList arguments of a function call (only literal arguments
+   *                    are passed, nulls for non-literal ones)
+   * @return element type of the table (e.g. {@code Object[].class})
+   */
+  public Type getElementType(RelDataTypeFactory typeFactory,
+      List<SqlNode> operandList) {
+    List<Object> arguments =
+      SqlUserDefinedTableMacro.convertArguments(typeFactory, operandList,
+        function, getNameAsId(), false);
+    return getFunction().getElementType(arguments);
+  }
+}
+
+// End SqlUserDefinedTableFunction.java

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedTableMacro.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlUserDefinedTableMacro.java
@@ -1,0 +1,137 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.sql.validate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+import org.eigenbase.reltype.RelDataTypeFactoryImpl;
+import org.eigenbase.sql.*;
+import org.eigenbase.sql.type.SqlOperandTypeChecker;
+import org.eigenbase.sql.type.SqlOperandTypeInference;
+import org.eigenbase.sql.type.SqlReturnTypeInference;
+import org.eigenbase.util.NlsString;
+import org.eigenbase.util.Pair;
+import org.eigenbase.util.Util;
+
+import net.hydromatic.linq4j.expressions.*;
+
+import net.hydromatic.optiq.Function;
+import net.hydromatic.optiq.FunctionParameter;
+import net.hydromatic.optiq.TableMacro;
+import net.hydromatic.optiq.TranslatableTable;
+import net.hydromatic.optiq.rules.java.RexToLixTranslator;
+
+/**
+ * User-defined table macro.
+ * <p>
+ * Created by the validator, after resolving a function call to a function
+ * defined in an Optiq schema.
+*/
+public class SqlUserDefinedTableMacro extends SqlFunction {
+  private final TableMacro tableMacro;
+
+  public SqlUserDefinedTableMacro(SqlIdentifier opName,
+        SqlReturnTypeInference returnTypeInference,
+        SqlOperandTypeInference operandTypeInference,
+        SqlOperandTypeChecker operandTypeChecker,
+        TableMacro tableMacro) {
+    super(Util.last(opName.names), opName, SqlKind.OTHER_FUNCTION,
+            returnTypeInference, operandTypeInference, operandTypeChecker,
+            null, null);
+    this.tableMacro = tableMacro;
+  }
+
+  /** Returns the table in this UDF, or null if there is no table. */
+  public TranslatableTable getTable(RelDataTypeFactory typeFactory,
+      List<SqlNode> operandList) {
+    List<Object> arguments = convertArguments(typeFactory, operandList,
+        tableMacro, getNameAsId(), true);
+    return tableMacro.apply(arguments);
+  }
+
+  /**
+   * Converts arguments from {@link org.eigenbase.sql.SqlNode} to java object
+   * format.
+   * @param typeFactory type factory used to convert the arguments
+   * @param operandList input arguments
+   * @param function target function to get parameter types from
+   * @param opName name of the operator to use in error message
+   * @param failOnNonLiteral true when conversion should fail on non-literal
+   * @return converted list of arguments
+   */
+  public static List<Object> convertArguments(RelDataTypeFactory typeFactory,
+      List<SqlNode> operandList, Function function,
+      SqlIdentifier opName,
+      boolean failOnNonLiteral) {
+    List<Object> arguments = new ArrayList<Object>(operandList.size());
+    // Construct a list of arguments, if they are all constants.
+    for (Pair<FunctionParameter, SqlNode> pair
+        : Pair.zip(function.getParameters(), operandList)) {
+      if (SqlUtil.isNullLiteral(pair.right, true)) {
+        arguments.add(null);
+      } else if (SqlUtil.isLiteral(pair.right)) {
+        final Object o = ((SqlLiteral) pair.right).getValue();
+        final Object o2 = coerce(o, pair.left.getType(typeFactory));
+        arguments.add(o2);
+      } else {
+        arguments.add(null);
+        if (failOnNonLiteral) {
+          throw new IllegalArgumentException(
+            "All arguments of call to macro " + opName + " should be "
+            + "literal. Actual argument #" + pair.left.getOrdinal() + " ("
+            + pair.left.getName() + ") is not literal: " + pair.right);
+        }
+      }
+    }
+    return arguments;
+  }
+
+  private static Object coerce(Object o, RelDataType type) {
+    if (!(type instanceof RelDataTypeFactoryImpl.JavaType)) {
+      return null;
+    }
+    final RelDataTypeFactoryImpl.JavaType javaType =
+        (RelDataTypeFactoryImpl.JavaType) type;
+    final Class clazz = javaType.getJavaClass();
+    //noinspection unchecked
+    if (clazz.isAssignableFrom(o.getClass())) {
+      return o;
+    }
+    if (clazz == String.class && o instanceof NlsString) {
+      return ((NlsString) o).getValue();
+    }
+    // We need optimization here for constant folding.
+    // Not all the expressions can be interpreted (e.g. ternary), so
+    // we rely on optimization capabilities to fold non-interpretable
+    // expressions.
+    BlockBuilder bb = new BlockBuilder();
+    final Expression expr =
+        RexToLixTranslator.convert(Expressions.constant(o), clazz);
+    bb.add(Expressions.return_(null, expr));
+    final FunctionExpression convert =
+        Expressions.lambda(bb.toBlock(),
+            Collections.<ParameterExpression>emptyList());
+    return convert.compile().dynamicInvoke();
+  }
+}
+
+// End SqlUserDefinedTableMacro.java

--- a/core/src/main/resources/org/eigenbase/resource/EigenbaseResource.properties
+++ b/core/src/main/resources/org/eigenbase/resource/EigenbaseResource.properties
@@ -147,6 +147,7 @@ NullIllegal=Illegal use of ''NULL''
 DynamicParamIllegal=Illegal use of dynamic parameter
 InvalidBoolean=''{0}'' is not a valid boolean value
 ArgumentMustBeValidPrecision=Argument to function ''{0}'' must be a valid precision between ''{1,number,#}'' and ''{2,number,#}''
+IllegalArgumentForTableFunctionCall=Wrong arguments for table function ''{0}'' call. Expected ''{1}'', actual ''{2}''
 InvalidDatetimeFormat=''{0}'' is not a valid datetime format
 InsertIntoAlwaysGenerated=Cannot explicitly insert value into IDENTITY column ''{0}'' which is ALWAYS GENERATED
 ArgumentMustHaveScaleZero=Argument to function ''{0}'' must have a scale of 0

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -22,6 +22,7 @@ import net.hydromatic.avatica.*;
 import net.hydromatic.linq4j.*;
 import net.hydromatic.linq4j.expressions.Types;
 import net.hydromatic.linq4j.function.Function1;
+import net.hydromatic.linq4j.function.Function2;
 
 import net.hydromatic.optiq.*;
 import net.hydromatic.optiq.impl.*;
@@ -75,7 +76,11 @@ import static org.junit.Assert.*;
  */
 public class JdbcTest {
   public static final Method GENERATE_STRINGS_METHOD =
-      Types.lookupMethod(JdbcTest.class, "generateStrings", Integer.TYPE);
+      Types.lookupMethod(JdbcTest.class, "generateStrings", Integer.class);
+
+  public static final Method MULTIPLICATION_TABLE_METHOD =
+      Types.lookupMethod(JdbcTest.class, "multiplicationTable", int.class,
+        int.class, Integer.class);
 
   public static final Method VIEW_METHOD =
       Types.lookupMethod(JdbcTest.class, "view", String.class);
@@ -83,6 +88,14 @@ public class JdbcTest {
   public static final Method STRING_UNION_METHOD =
       Types.lookupMethod(
           JdbcTest.class, "stringUnion", Queryable.class, Queryable.class);
+
+  public static final Method PROCESS_CURSOR_METHOD =
+      Types.lookupMethod(JdbcTest.class, "processCursor",
+          int.class, Enumerable.class);
+
+  public static final Method PROCESS_CURSORS_METHOD =
+      Types.lookupMethod(JdbcTest.class, "processCursors",
+          int.class, Enumerable.class, Enumerable.class);
 
   public static final String FOODMART_SCHEMA =
       "     {\n"
@@ -131,14 +144,8 @@ public class JdbcTest {
   }
 
   /**
-   * Tests a relation that is accessed via method syntax.
-   *
-   * <p>The function ({@link #generateStrings(int)} has a return type
-   * {@link Table} and the actual returned value implements
-   * {@link net.hydromatic.optiq.QueryableTable} but not
-   * {@link net.hydromatic.optiq.TranslatableTable}.
+   * Tests a table function with literal arguments.
    */
-  @Ignore
   @Test public void testTableFunction()
     throws SQLException, ClassNotFoundException {
     Class.forName("net.hydromatic.optiq.jdbc.Driver");
@@ -148,14 +155,156 @@ public class JdbcTest {
         connection.unwrap(OptiqConnection.class);
     SchemaPlus rootSchema = optiqConnection.getRootSchema();
     SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
-    final TableMacro tableMacro =
-        TableMacroImpl.create(GENERATE_STRINGS_METHOD);
-    schema.add("GenerateStrings", tableMacro);
+    final TableFunction table =
+        TableFunctionImpl.create(GENERATE_STRINGS_METHOD);
+    schema.add("GenerateStrings", table);
     ResultSet resultSet = connection.createStatement().executeQuery(
         "select *\n"
         + "from table(\"s\".\"GenerateStrings\"(5)) as t(n, c)\n"
         + "where char_length(c) > 3");
-    assertTrue(resultSet.next());
+    assertThat(OptiqAssert.toString(resultSet),
+        equalTo("N=4; C=abcd\n"));
+  }
+
+  /**
+   * Tests a table function that returns different row type based on
+   * actual call arguments.
+   */
+  @Test public void testTableFunctionDynamicStructure()
+    throws SQLException, ClassNotFoundException {
+    Connection connection = getConnectionWithMultiplyFunction();
+    final PreparedStatement ps = connection.prepareStatement(
+        "select *\n"
+        + "from table(\"s\".\"multiplication\"(4, 3, ?))\n"
+    );
+    ps.setInt(1, 100);
+    ResultSet resultSet = ps.executeQuery();
+    assertThat(OptiqAssert.toString(resultSet),
+        equalTo("row_name=row 0; c1=101; c2=102; c3=103; c4=104\n"
+                + "row_name=row 1; c1=102; c2=104; c3=106; c4=108\n"
+                + "row_name=row 2; c1=103; c2=106; c3=109; c4=112\n"));
+  }
+
+  /**
+   * Tests that non-nullable arguments of a table function must be provided
+   * as literals.
+   */
+  @Ignore("SQLException does not include message from nested exception")
+  @Test public void testTableFunctionNonNullableMustBeLiterals()
+    throws SQLException, ClassNotFoundException {
+    Connection connection = getConnectionWithMultiplyFunction();
+    try {
+      final PreparedStatement ps = connection.prepareStatement(
+          "select *\n"
+          + "from table(\"s\".\"multiplication\"(?, 3, 100))\n"
+      );
+      ps.setInt(1, 100);
+      ResultSet resultSet = ps.executeQuery();
+      fail("Should fail with ");
+    } catch (SQLException e) {
+      assertThat(e.getMessage(),
+          containsString("Wrong arguments for table function 'public static "
+                         + "net.hydromatic.optiq.QueryableTable net"
+                         + ".hydromatic.optiq.test.JdbcTest"
+                         + ".multiplicationTable(int,int,java.lang.Integer)'"
+                         + " call. Expected '[int, int, class"
+                         + "java.lang.Integer]', actual '[null, 3, 100]'"));
+    }
+  }
+
+  private Connection getConnectionWithMultiplyFunction()
+    throws ClassNotFoundException, SQLException {
+    Class.forName("net.hydromatic.optiq.jdbc.Driver");
+    Connection connection =
+        DriverManager.getConnection("jdbc:optiq:");
+    OptiqConnection optiqConnection =
+        connection.unwrap(OptiqConnection.class);
+    SchemaPlus rootSchema = optiqConnection.getRootSchema();
+    SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+    final TableFunction table =
+        TableFunctionImpl.create(MULTIPLICATION_TABLE_METHOD);
+    schema.add("multiplication", table);
+    return connection;
+  }
+
+  /**
+   * Tests a table function that takes cursor input.
+   */
+  @Ignore("CannotPlanException: Node [rel#18:Subset#4.ENUMERABLE.[]] "
+          + "could not be implemented")
+  @Test public void testTableFunctionCursorInputs()
+    throws SQLException, ClassNotFoundException {
+    Class.forName("net.hydromatic.optiq.jdbc.Driver");
+    Connection connection =
+        DriverManager.getConnection("jdbc:optiq:");
+    OptiqConnection optiqConnection =
+        connection.unwrap(OptiqConnection.class);
+    SchemaPlus rootSchema = optiqConnection.getRootSchema();
+    SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+    final TableFunction table =
+        TableFunctionImpl.create(GENERATE_STRINGS_METHOD);
+    schema.add("GenerateStrings", table);
+    final TableFunction add =
+        TableFunctionImpl.create(PROCESS_CURSOR_METHOD);
+    schema.add("process", add);
+    final PreparedStatement ps = connection.prepareStatement(
+        "select *\n"
+        + "from table(\"s\".\"process\"(2,\n"
+        + "cursor(select * from table(\"s\".\"GenerateStrings\"(?)))\n"
+        + ")) as t(u)\n"
+        + "where u > 3"
+    );
+    ps.setInt(1, 5);
+    ResultSet resultSet = ps.executeQuery();
+    // GenerateStrings returns 0..4, then 2 is added (process function),
+    // thus 2..6, finally where u > 3 leaves just 4..6
+    assertThat(OptiqAssert.toString(resultSet),
+        equalTo("u=4\n"
+                + "u=5\n"
+                + "u=6\n"));
+  }
+
+  /**
+   * Tests a table function that takes multiple cursor inputs.
+   */
+  @Ignore("CannotPlanException: Node [rel#24:Subset#6.ENUMERABLE.[]] "
+          + "could not be implemented")
+  @Test public void testTableFunctionCursorsInputs()
+    throws SQLException, ClassNotFoundException {
+    Class.forName("net.hydromatic.optiq.jdbc.Driver");
+    Connection connection =
+        getConnectionWithMultiplyFunction();
+    OptiqConnection optiqConnection =
+        connection.unwrap(OptiqConnection.class);
+    SchemaPlus rootSchema = optiqConnection.getRootSchema();
+    SchemaPlus schema = rootSchema.getSubSchema("s");
+    final TableFunction table =
+        TableFunctionImpl.create(GENERATE_STRINGS_METHOD);
+    schema.add("GenerateStrings", table);
+    final TableFunction add =
+        TableFunctionImpl.create(PROCESS_CURSORS_METHOD);
+    schema.add("process", add);
+    final PreparedStatement ps = connection.prepareStatement(
+        "select *\n"
+        + "from table(\"s\".\"process\"(2,\n"
+        + "cursor(select * from table(\"s\".\"multiplication\"(5,5,0))),\n"
+        + "cursor(select * from table(\"s\".\"GenerateStrings\"(?)))\n"
+        + ")) as t(u)\n"
+        + "where u > 3"
+    );
+    ps.setInt(1, 5);
+    ResultSet resultSet = ps.executeQuery();
+    // GenerateStrings produce 0..4
+    // multiplication produce 1..5
+    // process sums and adds 2
+    // sum is 2 + 1..9 == 3..9
+    assertThat(OptiqAssert.toString(resultSet),
+        equalTo("u=4\n"
+                + "u=5\n"
+                + "u=6\n"
+                + "u=7\n"
+                + "u=8\n"
+                + "u=9\n"));
   }
 
   /**
@@ -183,15 +332,32 @@ public class JdbcTest {
     // The call to "View('(10), (2)')" expands to 'values (1), (3), (10), (20)'.
     assertThat(OptiqAssert.toString(resultSet),
         equalTo("N=1\n"
-            + "N=3\n"
-            + "N=10\n"));
+                + "N=3\n"
+                + "N=10\n"));
   }
 
   /** Tests a JDBC connection that provides a model that contains a table
    *  macro. */
   @Test public void testTableMacroInModel() throws Exception {
     checkTableMacroInModel(TableMacroFunction.class);
+  }
+
+  /** Tests a JDBC connection that provides a model that contains a table
+   *  macro defined as a static method. */
+  @Test public void testStaticTableMacroInModel() throws Exception {
     checkTableMacroInModel(StaticTableMacroFunction.class);
+  }
+
+  /** Tests a JDBC connection that provides a model that contains a table
+   *  function. */
+  @Test public void testTableFunctionInModel() throws Exception {
+    checkTableMacroInModel(TestTableFunction.class);
+  }
+
+  /** Tests a JDBC connection that provides a model that contains a table
+   *  function defined as a static method. */
+  @Test public void testStaticTableFunctionInModel() throws Exception {
+    checkTableMacroInModel(TestStaticTableFunction.class);
   }
 
   private void checkTableMacroInModel(Class clazz) {
@@ -224,13 +390,10 @@ public class JdbcTest {
 
   /** A function that generates a table that generates a sequence of
    * {@link net.hydromatic.optiq.test.JdbcTest.IntString} values. */
-  public static Table generateStrings(final int count) {
+  public static QueryableTable generateStrings(final Integer count) {
     return new AbstractQueryableTable(IntString.class) {
       public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-        return typeFactory.builder()
-            .add("n", SqlTypeName.INTEGER)
-            .add("s", SqlTypeName.VARCHAR, -1)
-            .build();
+        return typeFactory.createJavaType(IntString.class);
       }
 
       public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
@@ -241,16 +404,18 @@ public class JdbcTest {
                 return new Enumerator<IntString>() {
                   static final String Z = "abcdefghijklm";
 
-                  int i = -1;
-                  IntString o;
+                  int i = 0;
+                  int curI;
+                  String curS;
 
                   public IntString current() {
-                    return o;
+                    return new IntString(curI, curS);
                   }
 
                   public boolean moveNext() {
-                    if (i < count - 1) {
-                      o = new IntString(i, Z.substring(0, i % Z.length()));
+                    if (i < count) {
+                      curI = i;
+                      curS = Z.substring(0, i % Z.length());
                       ++i;
                       return true;
                     } else {
@@ -259,7 +424,7 @@ public class JdbcTest {
                   }
 
                   public void reset() {
-                    i = -1;
+                    i = 0;
                   }
 
                   public void close() {
@@ -269,6 +434,117 @@ public class JdbcTest {
             };
         //noinspection unchecked
         return (Queryable<T>) queryable;
+      }
+    };
+  }
+
+  /** A function that generates multiplication table of {@code ncol} columns x
+   * {@code nrow} rows. */
+  public static QueryableTable multiplicationTable(final int ncol,
+      final int nrow, Integer offset) {
+    final int offs = offset == null ? 0 : offset;
+    return new AbstractQueryableTable(Object[].class) {
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        final RelDataTypeFactory.FieldInfoBuilder builder =
+          typeFactory.builder();
+        builder.add("row_name", typeFactory.createJavaType(String.class));
+        final RelDataType int_ = typeFactory.createJavaType(int.class);
+        for (int i = 1; i <= ncol; i++) {
+          builder.add("c" + i, int_);
+        }
+        return builder.build();
+      }
+
+      public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
+          SchemaPlus schema, String tableName) {
+        final List<Object[]> table = new AbstractList<Object[]>() {
+          @Override
+          public Object[] get(int index) {
+            Object[] cur = new Object[ncol + 1];
+            cur[0] = "row " + index;
+            for (int j = 1; j <= ncol; j++) {
+              cur[j] = j * (index + 1) + offs;
+            }
+            return cur;
+          }
+
+          @Override
+          public int size() {
+            return nrow;
+          }
+        };
+        BaseQueryable<Object[]> queryable =
+            new BaseQueryable<Object[]>(null, Object[].class, null) {
+              public Enumerator<Object[]> enumerator() {
+                return Linq4j.iterableEnumerator(table);
+              }
+            };
+        //noinspection unchecked
+        return (Queryable<T>) queryable;
+      }
+    };
+  }
+
+  /**
+   * A function that adds a number to the first column of input cursor
+   */
+  public static QueryableTable processCursor(final int offset,
+    final Enumerable<Object[]> a) {
+    return new AbstractQueryableTable(Object[].class) {
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory.builder()
+            .add("result", SqlTypeName.INTEGER)
+            .build();
+      }
+
+      public Queryable<Integer> asQueryable(QueryProvider queryProvider,
+          SchemaPlus schema, String tableName) {
+        final Enumerable<Integer> enumerable =
+            a.select(new Function1<Object[], Integer>() {
+              public Integer apply(Object[] a0) {
+                return offset + ((Integer) a0[0]);
+              }
+            });
+        BaseQueryable<Integer> queryable =
+            new BaseQueryable<Integer>(null, Integer.class, null) {
+              public Enumerator<Integer> enumerator() {
+                return enumerable.enumerator();
+              }
+            };
+        return queryable;
+      }
+    };
+  }
+
+  /**
+   * A function that sums the second column of first input cursor, second
+   * column of first input and the given int.
+   */
+  public static QueryableTable processCursors(final int offset,
+    final Enumerable<Object[]> a, final Enumerable<IntString> b
+  ) {
+    return new AbstractQueryableTable(Object[].class) {
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory.builder()
+            .add("result", SqlTypeName.INTEGER)
+            .build();
+      }
+
+      public Queryable<Integer> asQueryable(QueryProvider queryProvider,
+          SchemaPlus schema, String tableName) {
+        final Enumerable<Integer> enumerable =
+            a.zip(b, new Function2<Object[], IntString, Integer>() {
+              public Integer apply(Object[] v0, IntString v1) {
+                return ((Integer) v0[1]) + v1.n + offset;
+              }
+            });
+        BaseQueryable<Integer> queryable =
+            new BaseQueryable<Integer>(null, Integer.class, null) {
+              public Enumerator<Integer> enumerator() {
+                return enumerable.enumerator();
+              }
+            };
+        return queryable;
       }
     };
   }
@@ -4204,16 +4480,16 @@ public class JdbcTest {
       new Department(40, "HR", Collections.singletonList(emps[1])),
     };
 
-    public Table foo(int count) {
+    public QueryableTable foo(int count) {
       return generateStrings(count);
     }
 
-    public Table view(String s) {
+    public TranslatableTable view(String s) {
       return JdbcTest.view(s);
     }
   }
 
-  public static Table view(String s) {
+  public static TranslatableTable view(String s) {
     return new ViewTable(Object.class,
         new RelProtoDataType() {
           public RelDataType apply(RelDataTypeFactory typeFactory) {
@@ -4568,14 +4844,47 @@ public class JdbcTest {
   }
 
   public static class TableMacroFunction {
-    public Table eval(String s) {
+    public TranslatableTable eval(String s) {
       return view(s);
     }
   }
 
   public static class StaticTableMacroFunction {
-    public static Table eval(String s) {
+    public static TranslatableTable eval(String s) {
       return view(s);
+    }
+  }
+
+  private static QueryableTable oneThreePlus(String s) {
+    Integer latest = Integer.parseInt(s.substring(1, s.length() - 1));
+    List<Object> items = Arrays.<Object>asList(1, 3, latest);
+    final Enumerable<Object> enumerable = Linq4j.asEnumerable(items);
+    return new AbstractQueryableTable(Object[].class) {
+      public Queryable<Object> asQueryable(
+          QueryProvider queryProvider, SchemaPlus schema, String tableName) {
+        return new BaseQueryable<Object>(queryProvider, Object[].class, null) {
+          @Override
+          public Enumerator<Object> enumerator() {
+            return enumerable.enumerator();
+          }
+        };
+      }
+
+      public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        return typeFactory.builder().add("c", SqlTypeName.INTEGER).build();
+      }
+    };
+  }
+
+  public static class TestTableFunction {
+    public QueryableTable eval(String s) {
+      return oneThreePlus(s);
+    }
+  }
+
+  public static class TestStaticTableFunction {
+    public static QueryableTable eval(String s) {
+      return oneThreePlus(s);
     }
   }
 }


### PR DESCRIPTION
The structure (number of columns) might depend on the input arguments that are provided as literals (see `JdbcTest.multiplicationTable`)

This PR moves [Public Morozov](http://en.wikipedia.org/wiki/Pavlik_Morozov) out of `RexImpTable`, so `ScalarFunctionImpl` and `TableFunctionImpl` can properly implement the required call via linq4j (see `ImplementableFunction`).

Not included in current pull request:
- Table functions that take cursor parameters. It fails with `CannotPlanException`, see `JdbcTest.testTableFunctionCursorInputs`.
- Costing model (i.e. the number of rows returned by a function, io cost, cpu cost)
- Collation model
- Table function based on a method that returns `Enumerable`. 
- Configurable null policy for user-defined functions (see `ScalarFunctionImpl.createImplementor`)
