### PR TITLE
Provide SqlAdvisor via JDBC interface

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/DataContext.java
+++ b/core/src/main/java/net/hydromatic/optiq/DataContext.java
@@ -23,6 +23,7 @@ import net.hydromatic.linq4j.expressions.ParameterExpression;
 
 import net.hydromatic.optiq.impl.java.JavaTypeFactory;
 
+import org.eigenbase.sql.advise.SqlAdvisor;
 import org.eigenbase.util.Util;
 
 import java.lang.reflect.Modifier;
@@ -73,6 +74,9 @@ public interface DataContext {
 
     /** The Spark engine. Available if Spark is on the class path. */
     SPARK_CONTEXT("sparkContext", Object.class),
+
+    /** Sql advisor that suggests completion hints. */
+    SQL_ADVISOR("sqlAdvisor", SqlAdvisor.class),
 
     /** Time zone in which the current statement is executing. Required;
      * defaults to the time zone of the JVM if the connection does not specify a

--- a/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/OptiqConnectionImpl.java
@@ -30,8 +30,15 @@ import net.hydromatic.optiq.config.OptiqConnectionConfig;
 import net.hydromatic.optiq.config.OptiqConnectionProperty;
 import net.hydromatic.optiq.impl.AbstractSchema;
 import net.hydromatic.optiq.impl.java.JavaTypeFactory;
+import net.hydromatic.optiq.prepare.OptiqCatalogReader;
 import net.hydromatic.optiq.server.OptiqServer;
 import net.hydromatic.optiq.server.OptiqServerStatement;
+
+import org.eigenbase.sql.advise.SqlAdvisor;
+import org.eigenbase.sql.advise.SqlAdvisorValidator;
+import org.eigenbase.sql.fun.SqlStdOperatorTable;
+import org.eigenbase.sql.validate.SqlConformance;
+import org.eigenbase.sql.validate.SqlValidatorWithHints;
 
 import com.google.common.collect.*;
 
@@ -291,7 +298,24 @@ abstract class OptiqConnectionImpl
       if (o == AvaticaParameter.DUMMY_VALUE) {
         return null;
       }
+      if (o == null && Variable.SQL_ADVISOR.camelName.equals(name)) {
+        return getSqlAdvisor();
+      }
       return o;
+    }
+
+    private SqlAdvisor getSqlAdvisor() {
+      final OptiqConnectionImpl con = (OptiqConnectionImpl) queryProvider;
+      final String schemaName = con.getSchema();
+      List<String> schemaPath = schemaName == null
+                ? Collections.<String>emptyList()
+                : Collections.singletonList(schemaName);
+      final SqlValidatorWithHints validator =
+          new SqlAdvisorValidator(SqlStdOperatorTable.instance(),
+          new OptiqCatalogReader(rootSchema, con.config().caseSensitive(),
+              schemaPath, typeFactory),
+          typeFactory, SqlConformance.DEFAULT);
+      return new SqlAdvisor(validator);
     }
 
     public SchemaPlus getRootSchema() {

--- a/core/src/main/java/net/hydromatic/optiq/prepare/OptiqCatalogReader.java
+++ b/core/src/main/java/net/hydromatic/optiq/prepare/OptiqCatalogReader.java
@@ -139,11 +139,34 @@ public class OptiqCatalogReader implements Prepare.CatalogReader,
   }
 
   public List<SqlMoniker> getAllSchemaObjectNames(List<String> names) {
-    return null;
+    final OptiqSchema schema = getSchema(names);
+    if (schema == null) {
+      return Collections.emptyList();
+    }
+    List<SqlMoniker> result
+      = new ArrayList<SqlMoniker>();
+    final Map<String, OptiqSchema> schemaMap = schema.getSubSchemaMap();
+
+    for (String subSchema : schemaMap.keySet()) {
+      result.add(
+          new SqlMonikerImpl(schema.path(subSchema), SqlMonikerType.SCHEMA));
+    }
+
+    for (String table : schema.getTableNames()) {
+      result.add(
+          new SqlMonikerImpl(schema.path(table), SqlMonikerType.TABLE));
+    }
+
+    final NavigableSet<String> functions = schema.getFunctionNames();
+    for (String function : functions) { // views are here as well
+      result.add(
+          new SqlMonikerImpl(schema.path(function), SqlMonikerType.FUNCTION));
+    }
+    return result;
   }
 
-  public String getSchemaName() {
-    return null;
+  public List<String> getSchemaName() {
+    return defaultSchema;
   }
 
   public RelOptTableImpl getTableForMember(List<String> names) {

--- a/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/AbstractCursor.java
@@ -1046,6 +1046,17 @@ public abstract class AbstractCursor implements Cursor {
     }
 
     @Override
+    public Object getObject() {
+      final Object object = super.getObject();
+      if (object == null || object instanceof List) {
+        return object;
+      }
+      // The object can be java array in case of user-provided class for row
+      // storage.
+      return Primitive.asList(object);
+    }
+
+    @Override
     public Array getArray() {
       final List list = (List) getObject();
       if (list == null) {

--- a/core/src/main/java/org/eigenbase/sql/advise/SqlAdvisorGetHintsFunction.java
+++ b/core/src/main/java/org/eigenbase/sql/advise/SqlAdvisorGetHintsFunction.java
@@ -1,0 +1,111 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.sql.advise;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eigenbase.reltype.RelDataType;
+import org.eigenbase.reltype.RelDataTypeFactory;
+import org.eigenbase.rex.RexCall;
+import org.eigenbase.sql.validate.SqlMoniker;
+
+import net.hydromatic.linq4j.*;
+import net.hydromatic.linq4j.expressions.Expression;
+import net.hydromatic.linq4j.expressions.Expressions;
+import net.hydromatic.linq4j.expressions.Types;
+
+import net.hydromatic.optiq.*;
+import net.hydromatic.optiq.impl.ReflectiveFunctionBase;
+import net.hydromatic.optiq.rules.java.*;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * Table function that returns completion hints for a given sql.
+ */
+public class SqlAdvisorGetHintsFunction implements TableFunction,
+    ImplementableFunction {
+  private static final Expression ADVISOR =
+      Expressions.convert_(Expressions.call(
+        DataContext.ROOT,
+        BuiltinMethod.DATA_CONTEXT_GET.method,
+        Expressions.constant(DataContext.Variable.SQL_ADVISOR.camelName)),
+        SqlAdvisor.class);
+
+  private static final Method GET_COMPLETION_HINTS =
+      Types.lookupMethod(SqlAdvisorGetHintsFunction.class, "getCompletionHints",
+        SqlAdvisor.class, String.class, int.class);
+
+  private static final CallImplementor IMPLEMENTOR =
+    RexImpTable.createImplementor(new NotNullImplementor() {
+      public Expression implement(RexToLixTranslator translator,
+          RexCall call, List<Expression> operands) {
+        return Expressions.call(GET_COMPLETION_HINTS,
+            Iterables.concat(Collections.singleton(ADVISOR), operands));
+      }
+    }, NullPolicy.ANY, false);
+
+  private static final List<FunctionParameter> PARAMETERS =
+    ReflectiveFunctionBase.toFunctionParameters(String.class, int.class);
+
+  public CallImplementor getImplementor() {
+    return IMPLEMENTOR;
+  }
+
+  public RelDataType getRowType(RelDataTypeFactory typeFactory,
+      List<Object> arguments) {
+    return typeFactory.createJavaType(SqlAdvisorHint.class);
+  }
+
+  public Type getElementType(List<Object> arguments) {
+    return SqlAdvisorHint.class;
+  }
+
+  public List<FunctionParameter> getParameters() {
+    return PARAMETERS;
+  }
+
+  /**
+   * Returns completion hints for a given sql.
+   * Typically this is called from generated code ({@link org.eigenbase.sql
+   * .advise.SqlAdvisor.IMPLEMENTOR})
+   * @param advisor advisor to produce completion hints
+   * @param sql sql to complete
+   * @param pos cursor position in sql
+   * @return the table that contains completion hints for a given sql
+   */
+  public static Enumerable<SqlAdvisorHint> getCompletionHints(
+      final SqlAdvisor advisor, final String sql, final int pos) {
+    String[] replaced = new String[1];
+    final List<SqlMoniker> hints = advisor.getCompletionHints(sql,
+      pos, replaced);
+    final List<SqlAdvisorHint> res =
+        new ArrayList<SqlAdvisorHint>(hints.size() + 1);
+    res.add(new SqlAdvisorHint(replaced[0], null, "MATCH"));
+    for (SqlMoniker hint : hints) {
+      res.add(new SqlAdvisorHint(hint));
+    }
+    return Linq4j.asEnumerable(res).<SqlAdvisorHint>asQueryable();
+  }
+}
+
+// End SqlAdvisorGetHintsFunction.java

--- a/core/src/main/java/org/eigenbase/sql/advise/SqlAdvisorHint.java
+++ b/core/src/main/java/org/eigenbase/sql/advise/SqlAdvisorHint.java
@@ -1,0 +1,50 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package org.eigenbase.sql.advise;
+
+import java.util.List;
+
+import org.eigenbase.sql.validate.SqlMoniker;
+
+/**
+ * This class is used to return values for {@link SqlAdvisor#getCompletionHints
+ * (String, int, String[])}.
+ */
+public class SqlAdvisorHint {
+  /** Fully qualified object name as string. */
+  public final String id;
+  /** Fully qualified object name as array of names. */
+  public final String[] names;
+  /** One of {@link org.eigenbase.sql.validate.SqlMonikerType}. */
+  public final String type;
+
+  public SqlAdvisorHint(String id, String[] names, String type) {
+    this.id = id;
+    this.names = names;
+    this.type = type;
+  }
+
+  public SqlAdvisorHint(SqlMoniker id) {
+    this.id = id.toString();
+    final List<String> names = id.getFullyQualifiedNames();
+    this.names = names == null
+      ? null
+      : names.toArray(new String[names.size()]);
+    type = id.getType().name();
+  }
+}

--- a/core/src/main/java/org/eigenbase/sql/validate/DelegatingSqlValidatorCatalogReader.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/DelegatingSqlValidatorCatalogReader.java
@@ -53,7 +53,7 @@ public abstract class DelegatingSqlValidatorCatalogReader
     return catalogReader.getAllSchemaObjectNames(names);
   }
 
-  public String getSchemaName() {
+  public List<String> getSchemaName() {
     return catalogReader.getSchemaName();
   }
 }

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorCatalogReader.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorCatalogReader.java
@@ -56,18 +56,14 @@ public interface SqlValidatorCatalogReader {
   RelDataType getNamedType(SqlIdentifier typeName);
 
   /**
-   * Gets schema object names as specified. They can be schema or table
-   * object. If names array contain 1 element, return all schema names and all
-   * table names under the default schema (if that is set) If names array
-   * contain 2 elements, treat 1st element as schema name and return all table
-   * names in this schema
+   * Given fully qualified schema name, returns schema object names as
+   * specified. They can be schema, table, function, view.
+   * When names array is empty, the contents of root schema should be returned.
    *
-   * @param names the array contains either 2 elements representing a
-   *              partially qualified object name in the format of
-   *              'schema.object', or an unqualified name in the format of
-   *              'object'
-   * @return the list of all object (schema and table) names under the above
-   * criteria
+   * @param names the array contains fully qualified schema name or empty
+   *              list for root schema
+   * @return the list of all object (schema, table, function,
+   *         view) names under the above criteria
    */
   List<SqlMoniker> getAllSchemaObjectNames(List<String> names);
 
@@ -76,7 +72,7 @@ public interface SqlValidatorCatalogReader {
    *
    * @return name of the current schema
    */
-  String getSchemaName();
+  List<String> getSchemaName();
 
   /**
    * Finds a field with a given name, using the case-sensitivity of the current

--- a/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/eigenbase/sql/validate/SqlValidatorUtil.java
@@ -267,8 +267,7 @@ public class SqlValidatorUtil {
     if (subNames.size() == 0) {
       hints.addAll(
           catalogReader.getAllSchemaObjectNames(
-              Collections.singletonList(
-                  catalogReader.getSchemaName())));
+              catalogReader.getSchemaName()));
     }
   }
 

--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -46,6 +46,8 @@ import org.eigenbase.reltype.RelDataTypeFactory;
 import org.eigenbase.reltype.RelProtoDataType;
 import org.eigenbase.resource.EigenbaseNewResource;
 import org.eigenbase.sql.*;
+import org.eigenbase.sql.advise.SqlAdvisorGetHintsFunction;
+import org.eigenbase.sql.parser.SqlParserUtil;
 import org.eigenbase.sql.type.SqlTypeName;
 import org.eigenbase.util.Bug;
 import org.eigenbase.util.Pair;
@@ -308,6 +310,61 @@ public class JdbcTest {
   }
 
   /**
+   * Tests {@link org.eigenbase.sql.advise.SqlAdvisorGetHintsFunction}.
+   */
+  @Test public void testSqlAdvisorGetHintsFunction()
+    throws SQLException, ClassNotFoundException {
+    String res = adviseSql("select e.e^ from \"emps\" e");
+    assertThat(res,
+        equalTo("id=e; names=null; type=MATCH\n"
+                + "id=empid; names=[empid]; type=COLUMN\n"));
+  }
+  /**
+   * Tests {@link org.eigenbase.sql.advise.SqlAdvisorGetHintsFunction}.
+   */
+  @Test public void testSqlAdvisorSchemaNames()
+    throws SQLException, ClassNotFoundException {
+    String res = adviseSql("select empid from \"emps\" e, ^");
+    assertThat(res,
+        equalTo("id=; names=null; type=MATCH\n"
+                + "id=(; names=[(]; type=KEYWORD\n"
+                + "id=LATERAL; names=[LATERAL]; type=KEYWORD\n"
+                + "id=TABLE; names=[TABLE]; type=KEYWORD\n"
+                + "id=UNNEST; names=[UNNEST]; type=KEYWORD\n"
+                + "id=hr; names=[hr]; type=SCHEMA\n"
+                + "id=metadata; names=[metadata]; type=SCHEMA\n"
+                + "id=s; names=[s]; type=SCHEMA\n"
+                + "id=hr.depts; names=[hr, depts]; type=TABLE\n"
+                + "id=hr.emps; names=[hr, emps]; type=TABLE\n"));
+  }
+
+  private String adviseSql(String sql) throws ClassNotFoundException,
+      SQLException {
+    Class.forName("net.hydromatic.optiq.jdbc.Driver");
+    Properties info = new Properties();
+    info.put("lex", "JAVA");
+    info.put("quoting", "DOUBLE_QUOTE");
+    Connection connection =
+        DriverManager.getConnection("jdbc:optiq:", info);
+    OptiqConnection optiqConnection =
+        connection.unwrap(OptiqConnection.class);
+    SchemaPlus rootSchema = optiqConnection.getRootSchema();
+    rootSchema.add("hr", new ReflectiveSchema(new HrSchema()));
+    SchemaPlus schema = rootSchema.add("s", new AbstractSchema());
+    optiqConnection.setSchema("hr");
+    final TableFunction table =
+        new SqlAdvisorGetHintsFunction();
+    schema.add("get_hints", table);
+    PreparedStatement ps = connection.prepareStatement(
+        "select *\n"
+        + "from table(\"s\".\"get_hints\"(?, ?)) as t(id, names, type)");
+    SqlParserUtil.StringAndPos sap = SqlParserUtil.findPos(sql);
+    ps.setString(1, sap.sql);
+    ps.setInt(2, sap.cursor);
+    return OptiqAssert.toString(ps.executeQuery());
+  }
+
+  /**
    * Tests a relation that is accessed via method syntax.
    *
    * <p>The function ({@link #view(String)} has a return type
@@ -455,7 +512,7 @@ public class JdbcTest {
         return builder.build();
       }
 
-      public <T> Queryable<T> asQueryable(QueryProvider queryProvider,
+      public Queryable<Object[]> asQueryable(QueryProvider queryProvider,
           SchemaPlus schema, String tableName) {
         final List<Object[]> table = new AbstractList<Object[]>() {
           @Override
@@ -473,14 +530,7 @@ public class JdbcTest {
             return nrow;
           }
         };
-        BaseQueryable<Object[]> queryable =
-            new BaseQueryable<Object[]>(null, Object[].class, null) {
-              public Enumerator<Object[]> enumerator() {
-                return Linq4j.iterableEnumerator(table);
-              }
-            };
-        //noinspection unchecked
-        return (Queryable<T>) queryable;
+        return Linq4j.asEnumerable(table).<Object[]>asQueryable();
       }
     };
   }
@@ -505,13 +555,7 @@ public class JdbcTest {
                 return offset + ((Integer) a0[0]);
               }
             });
-        BaseQueryable<Integer> queryable =
-            new BaseQueryable<Integer>(null, Integer.class, null) {
-              public Enumerator<Integer> enumerator() {
-                return enumerable.enumerator();
-              }
-            };
-        return queryable;
+        return enumerable.asQueryable();
       }
     };
   }
@@ -538,13 +582,7 @@ public class JdbcTest {
                 return ((Integer) v0[1]) + v1.n + offset;
               }
             });
-        BaseQueryable<Integer> queryable =
-            new BaseQueryable<Integer>(null, Integer.class, null) {
-              public Enumerator<Integer> enumerator() {
-                return enumerable.enumerator();
-              }
-            };
-        return queryable;
+        return enumerable.asQueryable();
       }
     };
   }
@@ -5059,12 +5097,7 @@ public class JdbcTest {
     return new AbstractQueryableTable(Object[].class) {
       public Queryable<Object> asQueryable(
           QueryProvider queryProvider, SchemaPlus schema, String tableName) {
-        return new BaseQueryable<Object>(queryProvider, Object[].class, null) {
-          @Override
-          public Enumerator<Object> enumerator() {
-            return enumerable.enumerator();
-          }
-        };
+        return enumerable.asQueryable();
       }
 
       public RelDataType getRowType(RelDataTypeFactory typeFactory) {

--- a/core/src/test/java/org/eigenbase/test/MockCatalogReader.java
+++ b/core/src/test/java/org/eigenbase/test/MockCatalogReader.java
@@ -280,8 +280,8 @@ public class MockCatalogReader implements Prepare.CatalogReader {
     }
   }
 
-  public String getSchemaName() {
-    return DEFAULT_SCHEMA;
+  public List<String> getSchemaName() {
+    return Collections.singletonList(DEFAULT_SCHEMA);
   }
 
   public RelDataTypeField field(RelDataType rowType, String alias) {


### PR DESCRIPTION
Here's implementation of `SqlAdvisor` via table function available via JDBC as discussed in #151.
The function is not registered by default, the caller should include it to the desired schema.

PS. I do not like the way `SqlValidatorImpl#findAllValidUdfNames`: it asks all the object names in schema, then filters via `if (objName.getType() == SqlMonikerType.FUNCTION) {`, however that can be addressed separately.
