### PR TITLE
Avoid row computation on each accessor call

### DIFF
--- a/core/src/main/java/net/hydromatic/optiq/jdbc/MetaImpl.java
+++ b/core/src/main/java/net/hydromatic/optiq/jdbc/MetaImpl.java
@@ -925,26 +925,19 @@ public class MetaImpl implements Meta {
       }
     }
 
-    public Cursor cursor(final Enumerator<Object> enumerator) {
-      return new AbstractCursor() {
+    public Cursor cursor(Enumerator<Object> enumerator) {
+      //noinspection unchecked
+      return new EnumeratorCursor(enumerator) {
         protected Getter createGetter(final int ordinal) {
           return new Getter() {
             public Object getObject() {
-              return get(enumerator.current(), ordinal);
+              return get(current(), ordinal);
             }
 
             public boolean wasNull() {
               return getObject() == null;
             }
           };
-        }
-
-        public boolean next() {
-          return enumerator.moveNext();
-        }
-
-        public void close() {
-          enumerator.close();
         }
       };
     }

--- a/core/src/main/java/net/hydromatic/optiq/runtime/ArrayEnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/ArrayEnumeratorCursor.java
@@ -24,28 +24,18 @@ import net.hydromatic.linq4j.Enumerator;
  * {@link net.hydromatic.linq4j.Enumerator} that
  * returns an array of {@link Object} for each row.
  */
-public class ArrayEnumeratorCursor extends AbstractCursor {
-  private final Enumerator<Object[]> enumerator;
-
+public class ArrayEnumeratorCursor extends EnumeratorCursor<Object[]> {
   /**
    * Creates an ArrayEnumeratorCursor.
    *
    * @param enumerator Enumerator
    */
   public ArrayEnumeratorCursor(Enumerator<Object[]> enumerator) {
-    this.enumerator = enumerator;
+    super(enumerator);
   }
 
   protected Getter createGetter(int ordinal) {
     return new ArrayEnumeratorGetter(ordinal);
-  }
-
-  public boolean next() {
-    return enumerator.moveNext();
-  }
-
-  public void close() {
-    enumerator.close();
   }
 
   /** Implementation of {@link Getter} that reads from records that are
@@ -58,7 +48,7 @@ public class ArrayEnumeratorCursor extends AbstractCursor {
     }
 
     public Object getObject() {
-      Object o = enumerator.current()[field];
+      Object o = current()[field];
       wasNull[0] = o == null;
       return o;
     }

--- a/core/src/main/java/net/hydromatic/optiq/runtime/EnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/EnumeratorCursor.java
@@ -1,0 +1,69 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq.runtime;
+
+import net.hydromatic.linq4j.Enumerator;
+
+/**
+ * Implementation of {@link net.hydromatic.avatica.Cursor} on top of an
+ * {@link net.hydromatic.linq4j.Enumerator} that
+ * returns a record for each row. The returned record is cached to avoid
+ * multiple computations of current row.
+ * For instance,
+ * {@link net.hydromatic.optiq.rules.java.JavaRules.EnumerableCalcRel}
+ * computes result just in {@code current()} method, thus it makes sense to
+ * cache the result and make it available for all the accesors.
+ *
+ * @param <T> Element type
+ */
+public abstract class EnumeratorCursor<T> extends AbstractCursor {
+  private final Enumerator<T> enumerator;
+  private T current;
+
+  /**
+   * Creates a {@code EnumeratorCursor}
+   * @param enumerator input enumerator
+   */
+  protected EnumeratorCursor(Enumerator<T> enumerator) {
+    this.enumerator = enumerator;
+  }
+
+  public boolean next() {
+    if (enumerator.moveNext()) {
+      current = enumerator.current();
+      return true;
+    }
+    current = null;
+    return false;
+  }
+
+  public void close() {
+    current = null;
+    enumerator.close();
+  }
+
+  /**
+   * Returns current row.
+   * @return current row
+   */
+  protected T current() {
+    return current;
+  }
+}
+
+// End EnumeratorCursor.java

--- a/core/src/main/java/net/hydromatic/optiq/runtime/RecordEnumeratorCursor.java
+++ b/core/src/main/java/net/hydromatic/optiq/runtime/RecordEnumeratorCursor.java
@@ -29,8 +29,7 @@ import java.lang.reflect.Field;
  *
  * @param <E> Element type
  */
-public class RecordEnumeratorCursor<E> extends AbstractCursor {
-  private final Enumerator<E> enumerator;
+public class RecordEnumeratorCursor<E> extends EnumeratorCursor<E> {
   private final Class<E> clazz;
 
   /**
@@ -42,20 +41,12 @@ public class RecordEnumeratorCursor<E> extends AbstractCursor {
   public RecordEnumeratorCursor(
       Enumerator<E> enumerator,
       Class<E> clazz) {
-    this.enumerator = enumerator;
+    super(enumerator);
     this.clazz = clazz;
   }
 
   protected Getter createGetter(int ordinal) {
     return new RecordEnumeratorGetter(clazz.getFields()[ordinal]);
-  }
-
-  public boolean next() {
-    return enumerator.moveNext();
-  }
-
-  public void close() {
-    enumerator.close();
   }
 
   /** Implementation of {@link Getter} that reads fields via reflection. */
@@ -69,7 +60,7 @@ public class RecordEnumeratorCursor<E> extends AbstractCursor {
     public Object getObject() {
       Object o;
       try {
-        o = field.get(enumerator.current());
+        o = field.get(current());
       } catch (IllegalAccessException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
It turns out accessors for different columns do not share `enumerable.current()` row.
If the enumerable comes from `EnumerableCalcRel`, then `current()` contents is computed from scratch for each accessor even though just a single column is used.

Fix: cache the current value of enumerator. This might keep the row reachable a little bit longer, however I believe no harm is made: the reference is replaced on the next row and it is nullified as cursor is closed.

`ObjectEnumeratorCursor` is left as is (no caching) since its row contains just a single column, thus "multiple invocations from different column accessors" are not expected.
