### PR TITLE
Implement micro-benchmarks via JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <module>plus</module>
     <module>spark</module>
     <module>splunk</module>
+    <module>ubenchmark</module>
   </modules>
 
   <!-- Dependencies. -->
@@ -176,6 +177,21 @@
     </dependency>
   </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>net.hydromatic</groupId>
+        <artifactId>optiq-avatica</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.hydromatic</groupId>
+        <artifactId>optiq-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>
@@ -236,6 +252,16 @@
         </dependencies>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
 
     <resources>
       <resource>

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>optiq-parent</artifactId>
+    <groupId>net.hydromatic</groupId>
+    <version>0.7-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+    <top.dir>${project.basedir}/..</top.dir>
+  </properties>
+
+  <artifactId>optiq-ubenchmark</artifactId>
+  <description>Microbenchmarks for Optiq</description>
+
+  <repositories>
+    <repository>
+      <id>maven-central</id>
+      <url>http://repo1.maven.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>0.7.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.hydromatic</groupId>
+      <artifactId>optiq-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>ubenchmarks</finalName>
+              <filters>
+                  <filter>
+                      <!--
+                          Exclude files that sign a jar
+                          (one or multiple of the dependencies).
+                          One may not repack a signed jar without
+                          this, or you will get a
+                          SecurityException at program start.
+                      -->
+                      <artifact>*:*</artifact>
+                      <excludes>
+                          <exclude>META-INF/*.SF</exclude>
+                          <exclude>META-INF/*.RSA</exclude>
+                          <exclude>META-INF/*.INF</exclude> <!-- This one may not be required -->
+                      </excludes>
+                  </filter>
+              </filters>
+              <transformers>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ubenchmark/src/main/java/net/hydromatic/optiq/StatementTest.java
+++ b/ubenchmark/src/main/java/net/hydromatic/optiq/StatementTest.java
@@ -1,0 +1,234 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+package net.hydromatic.optiq;
+
+import net.hydromatic.optiq.impl.java.ReflectiveSchema;
+import net.hydromatic.optiq.jdbc.OptiqConnection;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.sql.*;
+import java.util.*;
+
+/**
+ * Compares {@link java.sql.Statement} vs {@link java.sql.PreparedStatement}.
+ */
+public class StatementTest {
+
+  /**
+   * Connection to be used during tests.
+   */
+  @State(Scope.Thread)
+  @BenchmarkMode(Mode.AverageTime)
+  public static class HrConnection {
+    Connection con;
+    int id;
+    HrSchema hr = new HrSchema();
+    Random rnd = new Random();
+    {
+      try {
+        Class.forName("net.hydromatic.optiq.jdbc.Driver");
+      } catch (ClassNotFoundException e) {
+        throw new IllegalStateException(e);
+      }
+      Connection connection;
+
+      try {
+        Properties info = new Properties();
+        info.put("lex", "JAVA");
+        info.put("quoting", "DOUBLE_QUOTE");
+        connection = DriverManager.getConnection("jdbc:optiq:", info);
+      } catch (SQLException e) {
+        throw new IllegalStateException(e);
+      }
+      OptiqConnection optiqConnection;
+      try {
+        optiqConnection = connection.unwrap(OptiqConnection.class);
+      } catch (SQLException e) {
+        throw new IllegalStateException(e);
+      }
+      final SchemaPlus rootSchema = optiqConnection.getRootSchema();
+      rootSchema.add("hr", new ReflectiveSchema(new HrSchema()));
+      try {
+        optiqConnection.setSchema("hr");
+      } catch (SQLException e) {
+        throw new IllegalStateException(e);
+      }
+      con = connection;
+    }
+
+    @Setup(Level.Iteration)
+    public void pickEmployee() {
+      id = hr.emps[rnd.nextInt(4)].empid;
+    }
+  }
+
+  /**
+   * Tests performance of reused execution of prepared statement.
+   */
+  public static class HrPreparedStatement extends HrConnection {
+    PreparedStatement ps;
+    {
+      try {
+        ps = con.prepareStatement("select name from emps where empid = ?");
+      } catch (SQLException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  @GenerateMicroBenchmark
+  public String prepareBindExecute(HrConnection state) throws SQLException {
+    Connection con = state.con;
+    Statement st = null;
+    ResultSet rs = null;
+    String ename = null;
+    try {
+      final PreparedStatement ps =
+          con.prepareStatement("select name from emps where empid = ?");
+      st = ps;
+      ps.setInt(1, state.id);
+      rs = ps.executeQuery();
+      rs.next();
+      ename = rs.getString(1);
+    } finally {
+      close(rs, st);
+    }
+    return ename;
+  }
+
+  @GenerateMicroBenchmark
+  public String bindExecute(HrPreparedStatement state)
+    throws SQLException {
+    PreparedStatement st = state.ps;
+    ResultSet rs = null;
+    String ename = null;
+    try {
+      st.setInt(1, state.id);
+      rs = st.executeQuery();
+      rs.next();
+      ename = rs.getString(1);
+    } finally {
+      close(rs, null); // Statement is not closed
+    }
+    return ename;
+  }
+
+  @GenerateMicroBenchmark
+  public String executeQuery(HrConnection state) throws SQLException {
+    Connection con = state.con;
+    Statement st = null;
+    ResultSet rs = null;
+    String ename = null;
+    try {
+      st = con.createStatement();
+      rs = st.executeQuery("select name from emps where empid = " + state.id);
+      rs.next();
+      ename = rs.getString(1);
+    } finally {
+      close(rs, st);
+    }
+    return ename;
+  }
+
+  @GenerateMicroBenchmark
+  public String forEach(HrConnection state) throws SQLException {
+    final Employee[] emps = state.hr.emps;
+    for (Employee emp : emps) {
+      if (emp.empid == state.id) {
+        return emp.name;
+      }
+    }
+    return null;
+  }
+
+  private static void close(ResultSet rs, Statement st) {
+    if (rs != null) {
+      try { rs.close(); } catch (SQLException e) { /**/ }
+    }
+    if (st != null) {
+      try { st.close(); } catch (SQLException e) { /**/ }
+    }
+  }
+
+  // Disable checkstyle, so it doesn't complain about fields like "customer_id".
+  //CHECKSTYLE: OFF
+
+  public static class HrSchema {
+    @Override
+    public String toString() {
+      return "HrSchema";
+    }
+
+    public final Employee[] emps = {
+      new Employee(100, 10, "Bill", 10000, 1000),
+      new Employee(200, 20, "Eric", 8000, 500),
+      new Employee(150, 10, "Sebastian", 7000, null),
+      new Employee(110, 10, "Theodore", 11500, 250),
+    };
+    public final Department[] depts = {
+      new Department(10, "Sales", Arrays.asList(emps[0], emps[2])),
+      new Department(30, "Marketing", Collections.<Employee>emptyList()),
+      new Department(40, "HR", Collections.singletonList(emps[1])),
+    };
+  }
+
+  public static class Employee {
+    public final int empid;
+    public final int deptno;
+    public final String name;
+    public final float salary;
+    public final Integer commission;
+
+    public Employee(int empid, int deptno, String name, float salary,
+        Integer commission) {
+      this.empid = empid;
+      this.deptno = deptno;
+      this.name = name;
+      this.salary = salary;
+      this.commission = commission;
+    }
+
+    public String toString() {
+      return "Employee [empid: " + empid + ", deptno: " + deptno
+          + ", name: " + name + "]";
+    }
+  }
+
+  public static class Department {
+    public final int deptno;
+    public final String name;
+    public final List<Employee> employees;
+
+    public Department(
+        int deptno, String name, List<Employee> employees) {
+      this.deptno = deptno;
+      this.name = name;
+      this.employees = employees;
+    }
+
+
+    public String toString() {
+      return "Department [deptno: " + deptno + ", name: " + name
+          + ", employees: " + employees + "]";
+    }
+  }
+
+}
+
+// End StatementTest.java

--- a/ubenchmark/src/main/java/net/hydromatic/optiq/package-info.java
+++ b/ubenchmark/src/main/java/net/hydromatic/optiq/package-info.java
@@ -1,0 +1,26 @@
+/*
+// Licensed to Julian Hyde under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership.
+//
+// Julian Hyde licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+/**
+ * Microbenchmarks to test optiq performance.
+ * The way to run is
+ * {@code mvn package && java -jar ./target/ubenchmarks.jar -wi 5 -i 5 -f 1}.
+ * <p>
+ * To run with profiling, use {@code java -Djmh.stack.lines=10 -jar
+ * ./target/ubenchmarks.jar -prof hs_comp,hs_gc,stack -f 1 -wi 5}.
+ */
+package net.hydromatic.optiq;


### PR DESCRIPTION
Here I add the micro-benchmarking module.
The purpose of the very first test (`StatementTest`) is to compare the performance of execution

``` sql
select name from hr.emps where empno=?
```

via four approaches:
1) plain java foreach looping through employees in `HrSchema` and finding the required `name`
2) `executeQuery(String)` with using literal for employee id
3) `prepareStatement(...); ps.setInt(...); ps.executeQuery()`
4) `ps.setInt(...); ps.executeQuery()` -- cached `PreparedStatement`

Here are the results:

```
Benchmark                                  Mode   Samples         Mean   Mean error    Units
n.h.o.StatementTest.forEach               thrpt        10   130285,170    31122,871   ops/ms
n.h.o.StatementTest.executeQuery          thrpt        10        0,043        0,007   ops/ms
n.h.o.StatementTest.prepareBindExecute    thrpt        10        0,042        0,008   ops/ms
n.h.o.StatementTest.bindExecute           thrpt        10      177,867        4,508   ops/ms
```

Note that cached and fully JIT'ed `PreparedStatement` looks to be 1000 times slower that foreach loop, however it achieves not that bad rate of 180 ops/ms == 180'000 / sec

A particular test can be investigated as follows: `java -Djmh.stack.lines=10 -jar ./target/ubenchmarks.jar ".*bindExecute.*" -prof hs_comp,hs_gc,stack -f 1 -wi 5 -i 20` (this runs `bindExecute` test with stack profiling in 1 jvm fork with 5 warmup iterations and 20 measurement iterations)

Here is sample result (it looks like lots of time is spent in creating of `DataContext` and in `OptiqConnectionProperty.wrap`):

```
       Stack |   5,7%   RUNNABLE java.util.Hashtable.hash
             |                   java.util.Hashtable.get
             |                   java.util.Properties.enumerateStringProperties
             |                   java.util.Properties.stringPropertyNames
             |                   net.hydromatic.avatica.ConnectionConfigImpl.parse
             |                   net.hydromatic.avatica.BuiltInConnectionProperty.wrap
             |                   net.hydromatic.avatica.ConnectionConfigImpl.timeZone
             |                   net.hydromatic.avatica.AvaticaConnection.getTimeZone
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl$DataContextImpl.<init>
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl.createDataContext
             | 
             |   5,7%   RUNNABLE java.util.Hashtable.<init>
             |                   java.util.Hashtable.<init>
             |                   java.util.Properties.stringPropertyNames
             |                   net.hydromatic.avatica.ConnectionConfigImpl.parse
             |                   net.hydromatic.optiq.config.OptiqConnectionProperty.wrap
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl$OptiqConnectionConfigImpl.autoTemp
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.avatica.AvaticaConnection.executeQueryInternal
             |                   net.hydromatic.avatica.AvaticaPreparedStatement.executeQuery
             | 
             |   5,7%   RUNNABLE sun.util.locale.LocaleUtils.isAlphaNumericString
             |                   sun.util.locale.UnicodeLocaleExtension.isKey
             |                   java.util.Locale.getUnicodeLocaleType
             |                   java.util.Calendar.createCalendar
             |                   java.util.Calendar.getInstance
             |                   net.hydromatic.avatica.AvaticaResultSet.<init>
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.<init>
             |                   net.hydromatic.optiq.jdbc.OptiqJdbc41Factory.newResultSet
             |                   net.hydromatic.optiq.jdbc.OptiqJdbc41Factory.newResultSet
             |                   net.hydromatic.avatica.AvaticaConnection.executeQueryInternal
             | 
             |   4,5%   RUNNABLE java.lang.String.toUpperCase
             |                   java.lang.String.toUpperCase
             |                   net.hydromatic.avatica.ConnectionConfigImpl.parse
             |                   net.hydromatic.optiq.config.OptiqConnectionProperty.wrap
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl$OptiqConnectionConfigImpl.autoTemp
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.avatica.AvaticaConnection.executeQueryInternal
             |                   net.hydromatic.avatica.AvaticaPreparedStatement.executeQuery
             |                   net.hydromatic.optiq.StatementTest.bindExecute
             | 
             |   4,5%   RUNNABLE java.util.HashMap.addEntry
             |                   java.util.LinkedHashMap.addEntry
             |                   java.util.HashMap.put
             |                   net.hydromatic.avatica.ConnectionConfigImpl.parse
             |                   net.hydromatic.optiq.config.OptiqConnectionProperty.wrap
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl$OptiqConnectionConfigImpl.autoTemp
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.avatica.AvaticaConnection.executeQueryInternal
             |                   net.hydromatic.avatica.AvaticaPreparedStatement.executeQuery
             | 
             |   4,5%   RUNNABLE java.lang.String.toUpperCase
             |                   java.lang.String.toUpperCase
             |                   net.hydromatic.avatica.ConnectionConfigImpl.parse
             |                   net.hydromatic.optiq.config.OptiqConnectionProperty.wrap
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl$OptiqConnectionConfigImpl.spark
             |                   net.hydromatic.optiq.jdbc.OptiqConnectionImpl.createDataContext
             |                   net.hydromatic.optiq.jdbc.MetaImpl.createCursor
             |                   net.hydromatic.avatica.AvaticaResultSet.execute
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
             |                   net.hydromatic.optiq.jdbc.OptiqResultSet.execute
```
