### PR TITLE
Reduce count(not null) to count()

### DIFF
--- a/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
+++ b/core/src/test/java/net/hydromatic/optiq/test/JdbcTest.java
@@ -2800,7 +2800,30 @@ public class JdbcTest {
             + " avg(\"deptno\") as a\n"
             + "from \"hr\".\"emps\"\n"
             + "where \"deptno\" < 0")
+        .explainContains(
+            "PLAN=EnumerableCalcRel(expr#0..2=[{inputs}], expr#3=[0], expr#4=[=($t0, $t3)], expr#5=[null], expr#6=[CASE($t4, $t5, $t1)], expr#7=[/($t2, $t0)], expr#8=[CAST($t7):JavaType(class java.lang.Integer)], CS=[$t0], C=[$t0], S=[$t6], A=[$t8])\n"
+            + "  EnumerableAggregateRel(group=[{}], CS=[COUNT()], agg#1=[$SUM0($0)], agg#2=[SUM($0)])\n"
+            + "    EnumerableCalcRel(expr#0..4=[{inputs}], expr#5=[0], expr#6=[<($t1, $t5)], deptno=[$t1], $condition=[$t6])\n"
+            + "      EnumerableTableAccessRel(table=[[hr, emps]])\n")
         .returns("CS=0; C=0; S=null; A=null\n");
+  }
+
+  /** Tests that count(deptno) is reduced to count(). */
+  @Test public void testReduceCountNotNullable() {
+    OptiqAssert.that()
+        .with(OptiqAssert.Config.REGULAR)
+        .query(
+            "select\n"
+            + " count(\"deptno\") as cs,\n"
+            + " count(*) as cs2\n"
+            + "from \"hr\".\"emps\"\n"
+            + "where \"deptno\" < 0")
+        .explainContains(
+            "PLAN=EnumerableCalcRel(expr#0=[{inputs}], CS=[$t0], CS2=[$t0])\n"
+            + "  EnumerableAggregateRel(group=[{}], CS=[COUNT()])\n"
+            + "    EnumerableCalcRel(expr#0..4=[{inputs}], expr#5=[0], expr#6=[<($t1, $t5)], DUMMY=[$t5], $condition=[$t6])\n"
+            + "      EnumerableTableAccessRel(table=[[hr, emps]])\n")
+        .returns("CS=0; CS2=0\n");
   }
 
   /** Tests sorting by a column that is already sorted. */

--- a/core/src/test/java/org/eigenbase/test/RelMetadataTest.java
+++ b/core/src/test/java/org/eigenbase/test/RelMetadataTest.java
@@ -330,11 +330,16 @@ public class RelMetadataTest extends SqlToRelTestBase {
         false);
   }
 
-  @Test public void testColumnOriginsAggMeasure() {
+  @Test public void testColumnOriginsAggReduced() {
+    checkNoColumnOrigin(
+        "select count(deptno),name from dept group by name");
+  }
+
+  @Test public void testColumnOriginsAggCountNullable() {
     checkSingleColumnOrigin(
-        "select count(deptno),name from dept group by name",
-        "DEPT",
-        "DEPTNO",
+        "select count(mgr),ename from emp group by ename",
+        "EMP",
+        "MGR",
         true);
   }
 

--- a/core/src/test/resources/org/eigenbase/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/eigenbase/test/RelOptRulesTest.xml
@@ -107,7 +107,7 @@ AggregateRel(group=[{0}], EXPR$1=[MAX($0)], EXPR$2=[AVG($1)], EXPR$3=[MIN($0)])
             <![CDATA[
 ProjectRel(NAME=[$0], EXPR$1=[$1], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[$4])
   ProjectRel(NAME=[$0], EXPR$1=[$1], $f2=[$2], $f3=[$3], EXPR$3=[$4])
-    AggregateRel(group=[{0}], EXPR$1=[MAX($0)], agg#1=[$SUM0($1)], agg#2=[COUNT($1)], EXPR$3=[MIN($0)])
+    AggregateRel(group=[{0}], EXPR$1=[MAX($0)], agg#1=[$SUM0($1)], agg#2=[COUNT()], EXPR$3=[MIN($0)])
       ProjectRel(NAME=[$1], DEPTNO=[$0])
         TableAccessRel(table=[[CATALOG, SALES, DEPT]])
 ]]>

--- a/core/src/test/resources/org/eigenbase/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/eigenbase/test/SqlToRelConverterTest.xml
@@ -63,7 +63,7 @@ ProjectRel(DEPTNO=[$0], EXPR$1=[$1])
         <Resource name="plan">
             <![CDATA[
 ProjectRel(EXPR$0=[+($0, 4)], EXPR$1=[$1], EXPR$2=[$2], EXPR$3=[*(2, $3)])
-  AggregateRel(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], agg#2=[COUNT($1)])
+  AggregateRel(group=[{0}], EXPR$1=[SUM($1)], EXPR$2=[SUM($2)], agg#2=[COUNT()])
     ProjectRel(DEPTNO=[$7], SAL=[$5], $f2=[+(3, $5)])
       TableAccessRel(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -130,7 +130,7 @@ ProjectRel(NAME=[$0])
             <![CDATA[
 ProjectRel(NAME=[$1], FOO=[$2])
   ProjectRel(DEPTNO=[$1], NAME=[$0], FOO=[$2])
-    AggregateRel(group=[{0, 1}], FOO=[COUNT($1)])
+    AggregateRel(group=[{0, 1}], FOO=[COUNT()])
       ProjectRel(NAME=[$1], DEPTNO=[$0])
         TableAccessRel(table=[[CATALOG, SALES, DEPT]])
 ]]>


### PR DESCRIPTION
When `AVG(x)` and similar aggregates are transformed to `SUM(x)/COUNT(x)`, the `COUNT(x)` tend to duplicate.

I suggest check for non-distinct `COUNT` with at least one not-null argument and use plain `COUNT()`. 
